### PR TITLE
Don't include player in other fascists chat notification

### DIFF
--- a/routes/socket/game/start-game.js
+++ b/routes/socket/game/start-game.js
@@ -157,7 +157,8 @@ const {sendInProgressGameUpdate} = require('../util.js'),
 						}
 						player.playersState[otherFascistIndex].notificationStatus = 'fascist';
 					} else if (playerCount > 8) {
-						const otherFascists = seatedPlayers.filter(player => player.role.cardName === 'fascist');
+						const otherFascists = seatedPlayers.filter(play => 
+							play.role.cardName === 'fascist' && play.userName !== player.userName);
 
 						if (!game.general.disableGamechat) {
 							player.gameChats.push({


### PR DESCRIPTION
Hi, this PR addresses an in-game bug. 

In 9-10p games, the chat notification "You see that the other fascists in the game are..." will be incorrect for 2 fascists. They will see themselves listed instead of the fascist seated furthest to the right.

![screen shot 2017-03-16 at 12 49 00 pm](https://cloud.githubusercontent.com/assets/5355316/24018057/a2269c58-0a4f-11e7-9924-3d4f254def4f.png)

This isn't game breaking, as you can still determine other fascists by looking at the color of the names on the board. But, it is a bit inconvenient and can be confusing to newer players who are not familiar with the UI.

This fix simply filters the "other fascists" list to not include the player itself. The previously hidden fascist will now be correctly shown.