### PR TITLE
Crash fixes

### DIFF
--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -59,7 +59,7 @@ const {games, userList, generalChats} = require('./models'),
 
 				if (gameState.isStarted && !gameState.isCompleted) {
 					publicPlayersState[playerIndex].connected = false;
-					sendInProgressGameUpdate(game);
+					io.in(game.uid).emit('gameUpdate', game);
 				} else if (gameState.isCompleted && game.publicPlayersState.filter(player => !player.connected || player.leftGame).length === game.general.playerCount - 1) {
 					saveGame(game);
 					games.splice(games.indexOf(game), 1);
@@ -199,7 +199,7 @@ module.exports.handleUserLeaveGame = (socket, data) => {
 	}
 
 	if (game && game.gameState.isStarted && data.isSeated) {
-		const playerIndex = game.private.seatedPlayers.findIndex(player => player.userName === data.userName);
+		const playerIndex = game.publicPlayersState.findIndex(player => player.userName === data.userName);
 
 		game.publicPlayersState[playerIndex].leftGame = true;
 
@@ -219,7 +219,7 @@ module.exports.handleUserLeaveGame = (socket, data) => {
 	if (game && !game.publicPlayersState.length) {
 		io.sockets.in(data.uid).emit('gameUpdate', {});
 		games.splice(games.indexOf(game), 1);
-	} else if (game && game.gameState.isStarted) {
+	} else if (game && game.isTracksFlipped) {
 		sendInProgressGameUpdate(game);
 	}
 

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -82,6 +82,12 @@ const {games, userList, generalChats} = require('./models'),
 module.exports.updateSeatedUser = (socket, data) => {
 	const game = games.find(el => el.general.uid === data.uid);
 
+	// prevents race condition between 1) taking a seat and 2) the game starting
+	if (game && game.gameState.isTracksFlipped) {
+		console.warn('player joined too late');
+		return;
+	}
+
 	if (game && game.publicPlayersState.length < game.general.maxPlayersCount && (!game.general.private || (game.general.private && data.password === game.private.privatePassword))) {
 		const {publicPlayersState} = game;
 

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -57,7 +57,10 @@ const {games, userList, generalChats} = require('./models'),
 				const {gameState, publicPlayersState} = game,
 					playerIndex = publicPlayersState.findIndex(player => player.userName === passport.user);
 
-				if (gameState.isStarted && !gameState.isCompleted) {
+				if (gameState.isTracksFlipped && !gameState.isCompleted) {
+					publicPlayersState[playerIndex].connected = false;
+					sendInProgressGameUpdate(game);
+				} else if (gameState.isStarted && !gameState.isCompleted) {
 					publicPlayersState[playerIndex].connected = false;
 					io.in(game.uid).emit('gameUpdate', game);
 				} else if (gameState.isCompleted && game.publicPlayersState.filter(player => !player.connected || player.leftGame).length === game.general.playerCount - 1) {


### PR DESCRIPTION
Continuing the discussion from #13...

Using the logs you've provided, I've been able to trace some of the reasons the server is crashing:

### 1) A seated player leaves or disconnects from the game during the countdown.

**Issue:** `game.isStarted` conflated with `startGame(game)`. Some references like `game.private.seatedPlayers` are still undefined when the game is counting down but not yet started.

**Fix**: Make sure undefined references are not used when game is counting down. `module.exports.sendInProgressGameUpdate` in `routes/socket/util.js` is a big culprit. Piggyback off of `game.gameState.isTracksFlipped` to determine if game is initialized.

### 2) A player is seated after the game is initialized.

**Issue:** Due to latency, a player can be seated after the game is initialized.

`user requests seat ---> game initialized ---> server receives request`

**Fix**: Prevent the user from seating if the game has already started.

---

I've created a branch that you can use to verify this: https://github.com/jbasrai/secret-hitler/tree/crash-reproduce. I've overwritten the README file with instructions to reproduce the crashes.