### PR TITLE
Add script to dump a day's game summaries.

### DIFF
--- a/scripts/dumpGames.js
+++ b/scripts/dumpGames.js
@@ -1,0 +1,71 @@
+const mongoose = require('mongoose');
+const Game = require('../models/game');
+const GameSummary = require('../models/game-summary');
+const { List } = require('immutable');
+const debug = require('debug')('game:summary');
+
+
+/**
+ * This script gets all game summaries for a day, strips personally
+ * identifiable player information, and outputs the contents of the summaries
+ * to stdout.
+ */
+
+
+// Determine the date for which we want to dump game summaries
+//
+// ... validate args
+if (process.argv.length >= 4) {
+    console.log(`Usage: ${process.argv[0]} ${process.argv[1]} [date (e.g. "2017-01-31")]`);
+    process.exit(1);
+}
+// ... get the date, if passed in
+if (process.argv.length == 3) {
+    if (isNaN(Date.parse(process.argv[2]))) {
+        console.log(`Invalid date: "${date}".  Expected format: "YYYY-MM-DD".`);
+        process.exit(1);
+    }
+    startDate = new Date(process.argv[2]);
+}
+// ... default to today
+if (process.argv.length == 2) {
+    startDate = new Date();
+}
+endDate = new Date(startDate.getTime() + (24 * 60 * 60 * 1000));
+dumpDateFrom = `${startDate.getFullYear()}-${startDate.getMonth()+1}-${startDate.getDate()}`;
+dumpDateTo = `${endDate.getFullYear()}-${endDate.getMonth()+1}-${endDate.getDate()}`;
+
+
+// Connect to mongo
+mongoose.Promise = global.Promise;
+mongoose.connect('mongodb://localhost/secret-hitler-app');
+
+
+// Dump summaries for the day
+var summaries = [];
+console.log(new Date(dumpDateFrom))
+console.log(new Date(dumpDateTo))
+GameSummary.find({
+        date: {$gte: new Date(dumpDateFrom), $lt: new Date(dumpDateTo)}
+    })
+    .lean()
+	.cursor()
+	.eachAsync(summary => {
+
+        // ... strip personally identifable information
+        for (i = 0; i < summary.players.length; i++) {
+            delete summary.players[i]._id
+            delete summary.players[i].username
+        }
+        summaries.push(summary);
+
+	})
+	.then(() => {
+
+        // ... dump summaries to stdout
+        console.log(JSON.stringify(summaries, null, 2));
+
+        // ... close db connection
+		mongoose.connection.close();
+
+	});


### PR DESCRIPTION
This dumps the game summaries for all games on a particular day into a tar.gz archive.  It anonymizes the games before dumping them.

I've never done anything in node before, so let me know if some of this makes your eyes bleed.  I wasn't too concerned with what is sync vs async since it won't be running in-request.  I hate the way the date parsing stuff is done, but I was surprised to find a lack of date string formatting options built into JS, and I'm not a big fan of adding dependencies willy-nilly.

The only lingering question I see is where to store the data.  I was thinking we could set up a public S3 bucket.  I'm happy to share the costs of this as well for a while.  I could just send you some money.

Ah, I guess I'm also curious as to whether you're still running all of this on a single digital ocean box.  Is the database split off onto another instance at least?  It would probably be good to do some napkin math on how many games per day you have to see whether this will be a big DB impact.  The size of the game summaries are pretty small, so I don't imagine it will be that big of a deal.