### PR TITLE
If all players leave a game, observers will be returned to the lobby.

### DIFF
--- a/src/frontend-scripts/components/section-main/Game.jsx
+++ b/src/frontend-scripts/components/section-main/Game.jsx
@@ -20,6 +20,11 @@ export default class Game extends React.Component {
 				sound.pause();
 			}, 2400);
 		}
+		// All players have left the game, so we will return the observer to the main screen.
+		if ((!gameInfo.publicPlayersState.length && !(gameInfo.general.isTourny && gameInfo.general.tournyInfo.round === 0)) ||
+			(gameInfo.general.isTourny && gameInfo.general.tournyInfo.round === 0 && !gameInfo.general.tournyInfo.queuedPlayers.length)) {
+			window.location.hash = '#/';
+		}
 	}
 
 	render() {


### PR DESCRIPTION
PR in response to issue https://github.com/cozuya/secret-hitler/issues/412


Part of me feels like we should have a special event emitted before we splice a game out of the list and we can just listen for that instead, but this code will work in the interim.