### PR TITLE
Adding .idea to the gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ public/styles/style-dark.css
 public/styles/style-light.css
 public/styles/style-web.css
 coverage/*
+.idea/


### PR DESCRIPTION
Jetbrains IDEs generate an .idea folder and this can be accidentally added to the repository by those who are contributing. This will stop that!