### PR TITLE
Issue #675 Tournament crowns are visible in blind mode (again) Fix

### DIFF
--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -370,7 +370,10 @@ class Gamechat extends React.Component {
 					) : (
 						<div className="item" key={i}>
 							{this.handleTimestamps(chat.timestamp)}
-							{!(gameSettings && Object.keys(gameSettings).length && gameSettings.disableCrowns) && chat.tournyWins && renderCrowns(chat.tournyWins)}
+							{!(gameSettings && Object.keys(gameSettings).length && gameSettings.disableCrowns) &&
+								chat.tournyWins &&
+								!isBlind &&
+								renderCrowns(chat.tournyWins)}
 							<span
 								className={
 									playerListPlayer


### PR DESCRIPTION
This should fix the problem that crowns are displayed while blind mode is enabled.
Signed-off-by: Martin Kromm <mart.kro@gmx.de>