### PR TITLE
Rules page made cleaner. Added a glossary/strategies section.

### DIFF
--- a/views/page-rules.pug
+++ b/views/page-rules.pug
@@ -2,13 +2,12 @@ extends layout
 block content
 	.ui.container.rules-container
 		.ui.text.container
-			h1.ui.header.centered The rules of Secret Hitler
+			h1.ui.header.centered The Rules of Secret Hitler
 		.ui.text.container
 			p.understated The year is 1932. The place is pre-WWII Germany. In Secret Hitler, players are German politicians attempting to hold a fragile Liberal government together and stem the rising tide of Fascism. Watch out though—there are secret Fascists among you, and one player is Secret Hitler.
 			h2.ui.header.centered OVERVIEW
-			p At the beginning of the game, each player is secretly assigned to one of three roles: <span class="emphasis">Liberal, Fascist, or Hitler.</span> The Liberals have a majority, but they don’t know for sure who anyone is; Fascists must resort to secrecy and sabotage to accomplish their goals. Hitler plays for the Fascist team, and the Fascists know Hitler’s identity from the outset, but Hitler doesn’t know the Fascists and must work to figure them out.
-			p.emphasis The Liberals win by enacting five Liberal Policies or killing Hitler. The Fascists win by enacting six Fascist Policies, or if Hitler is elected Chancellor after three Fascist Policies have been enacted.
-			p Whenever a Fascist Policy is enacted, the government becomes more powerful, and the President is granted a single-use power which must be used before the next round can begin. It doesn’t matter what team the President is on; in fact, even Liberal players might be tempted to enact a Fascist Policy to gain new powers.
+			p At the beginning of the game, each player is secretly assigned one of the three roles: <span class="emphasis">Liberal</span>, <span class="emphasis">Fascist</span>, or <span class="emphasis">Hitler</span>. The Liberals have a majority, but they don’t know the roles of other players; Fascists must resort to secrecy and sabotage to accomplish their goals. Fascists know the identities of the other Fascists and Hitler. Hitler plays for the Fascist team, but doesn't know who the other Fascists are and must work to figure them out.
+			p Whenever a Fascist Policy is enacted, the government becomes more powerful, and the President is granted a single-use power which must be used before the next round can begin. These powers range from choosing the next President to killing one of the players.
 			h2.ui.header.centered OBJECT
 			p Every player has a secret identity as a member of either the Liberal team or the Fascist team. Players on the Liberal team win if either:
 			ul
@@ -18,9 +17,9 @@ block content
 			ul
 				li Six Fascist Policies are enacted OR
 				li Hitler is elected Chancellor any time after the third Fascist Policy has been enacted.
-			h2.ui.header.centered SET UP
+			h2.ui.header.centered SETUP
 			p The 11 Fascist Policy tiles and the 6 Liberal Policy tiles are shuffled into a single Policy deck.
-			p Each player will receive a Secret Role card. The table below determines the correct distribution of roles.
+			p Each player will receive a Secret Role card. The table below determines the correct distribution of roles and whether Hitler knows who the Fascists are or not.
 			table
 				thead
 					tr.emphasis
@@ -36,10 +35,10 @@ block content
 						td Fascists
 						each val in ['1+H', '1+H', '2+H', '2+H', '3+H', '3+H']
 							td= val
-			h4.ui.header.centered.aside WHY ARE THERE SECRET ROLE AND PARTY MEMBERSHIP CARDS?
-			p.aside Secret Hitler features an investigation mechanic that allows some players to find out what team other players are on, and this mechanic only works if Hitler’s special role is not revealed. To prevent that from happening, every player has both a Secret Role card and a Party membership card. Hitler’s Party Membership card shows a Fascist party loyalty, but gives no hint about a special role. Liberals who uncover Fascists must work out for themselves whether they’ve found an ordinary Fascist or their leader. 
-			p For games of 5-6 players: the Fascist player and Hitler player get to see and identify each other.  Liberals know nothing.
-			p For games of 7-10 players: the fascist players get to see and identify each other, and know who the Hitler player is.  Hitler and Liberals know nothing.
+					tr
+						td Fascists known by Hitler?
+						each val in ['Yes', 'Yes', 'No', 'No', 'No', 'No']
+							td= val
 			h2.ui.header.centered GAMEPLAY
 			p Secret Hitler is played in rounds. Each round has an Election to form a government, a Legislative Session to enact a new Policy, and an Executive Action to exercise governmental power.
 			h4.ui.header.centered ELECTION
@@ -55,28 +54,26 @@ block content
 				li If there are only five players left in the game, only the last elected Chancellor is ineligible to be Chancellor Candidate; the last President may be nominated.
 				li There are some other rules that affect eligibility in specific ways: the Veto Power and the Election Tracker. You don’t need to worry about those yet, and we’ll talk about each one in its relevant section.
 			p.emphasis 3. Vote on the government
-			p Once the Presidential Candidate has chosen an eligible Chancellor Candidate, players may discuss the proposed government until everyone is ready to vote. Every player, including the Candidates, votes on the proposed government. Once everyone is ready to vote, the Ballot cards are revealed simultaneously.
+			p Once the Presidential Candidate has chosen an eligible Chancellor Candidate, players may discuss the proposed government until everyone has cast their votes. All players, including the President and Chancellor Candidate, vote on the proposed government. Once everyone has cast their vote, the Ballot cards are revealed simultaneously.
 			p.emphasis If the vote is a tie, or if a majority of players votes no:
 			p The vote fails. The Presidential Candidate misses this chance to be elected, and the President placard moves to the next player. The Election Tracker is advanced by one Election.
-			p Election Tracker: If the group rejects three governments in a row, the country is thrown into chaos. The next policy is revealed and enacted. Any power granted by this Policy is ignored, but the Election Tracker resets, and existing term-limits are forgotten. All players become eligible to hold the office of Chancellor for the next Election. If there are fewer than three tiles remaining in the Policy deck at this point, they are shuffled with the Discard pile to create a new Policy deck.
-			p Any time a new Policy tile is played face-up, the Election Tracker is reset, whether it was enacted by an elected government or enacted by the frustrated populace.
-			p.emphasis If a majority of players votes yes:
+			p Election Tracker: If the group rejects three governments in a row, the country is thrown into chaos. The next Policy on the top of the deck is revealed and enacted. Any power granted by this Policy is ignored, but the Election Tracker resets, and any existing term-limits are forgotten. If there are fewer than three tiles remaining in the Policy deck at this point, they are shuffled with the Discard pile to create a new Policy deck.
+			p Any time a new Policy is enacted for any reason, the Election Tracker is reset.
+			p.emphasis If a majority of players vote yes:
 			p The Presidential Candidate and Chancellor Candidate become the new President and Chancellor, respectively.
-			p.emphasis If three or more Fascist Policies have been enacted already:
-			p If the new Chancellor is Hitler, the game is over and the Fascists win. Otherwise, other players know for sure the Chancellor is not Hitler.
+			p.emphasis If three or more Fascist Policies have been enacted and a majority of players vote yes:
+			p If the new Chancellor is Hitler, the game is over and the Fascists win. If the game didn't end, other players will know for sure the Chancellor is not Hitler.
 			h4.ui.header.centered LEGISLATIVE SESSION
-			p During the Legislative Session, the President and Chancellor work together to enact a new Policy in secret. The President draws the top three tiles from the Policy deck, looks at them in secret, and discards one tile face down into the Discard pile. The remaining two tiles go to the Chancellor, who looks in secret, discards one Policy tile face down, and enacts the remaining Policy by placing the tile face up on the corresponding track.
-			p The chat for the President and Chancellor is disabled. Attempting to telegraph the contents of your hand using randomness or any other unusual selection procedure violates the spirit of the game.  Don’t do it.
+			p During the Legislative Session, the President and Chancellor work together to enact a new Policy in secret. The President draws the top three tiles from the Policy deck, looks at them in secret, and discards one tile face down into the Discard pile. The remaining two tiles go to the Chancellor, who in secret discards one Policy tile face down, and enacts the remaining Policy by placing the tile face up on the corresponding track.
+			p The chat for the President and Chancellor is disabled during the Legislative Session. Attempting to telegraph the contents of your hand using randomness or any other unusual selection procedure violates the spirit of the game. Don’t do it.
 			p.emphasis Discarded Policy tiles are not revealed to the group. Players must rely on the word of the President and Chancellor, who are free to lie.
 			p.aside ABOUT LYING: Often, some players learn things that the rest of the players don’t know, like when the President and Chancellor get to see Policy tiles, or when a President uses the Investigate power to see someone’s Party Membership card. You can always lie about hidden knowledge in Secret Hitler.
-			p <span class="emphasis">If there are fewer than three tiles remaining in the Policy deck at the end of a Legislative Session, </span>they are shuffled with the Discard pile to create a new Policy deck. Unused Policy tiles are not revealed.
-			p <span class="emphasis">If the government enacted a Fascist Policy that covered up a Presidential Power,</span> the sitting President gets to use that power. Proceed to the Executive Action.
-			p <span class="emphasis">If the government enacted a Liberal Policy or a Fascist Policy that grants no Presidential Power,</span> begin a new round with a new Election.
+			p <span class="emphasis">If there are fewer than three tiles remaining in the Policy deck at the end of a Legislative Session,</span> they are shuffled with the Discard pile to create a new Policy deck. Unused Policy tiles are not revealed.
 			h4.ui.header.centered EXECUTIVE ACTION
-			p If the newly-enacted Fascist Policy grants a Presidential Power, the President must use it before the next round can begin. Before using a power, the President is free to discuss the issue with other players, but ultimately the President gets to decide how and when the power is used. Gameplay cannot continue until the President uses the power. Presidential Powers are used only once; they don’t stack or roll over to future turns.
+			p If the newly-enacted Fascist Policy grants a Presidential Power, the President must use it before the next round can begin. Before using a power, the President is free to discuss the issue with other players, but ultimately the President gets to decide how and when the power is used. Gameplay cannot continue until the President uses the power. Presidential Powers are used only once; they don’t stack or roll over to future turns. If the government enacted a Liberal or Fascist Policy that grants no Presidential Power, begin the next round with a new Election.
 			h4.ui.header.centered PRESIDENTIAL POWERS
 			p.emphasis Investigate Loyalty
-			p The President chooses a player to investigate. Investigated players show their Party Membership (not Secret Role!) to the President. The President may share (or lie about!) the results of their investigation at their discretion. No player may be investigated twice in the same game.
+			p The President chooses a player to investigate. Investigated players show their Party Membership (not the secret role card that also reveals whether the player is Hitler or not, not just whether he's a Liberal or Fascist) to the President. The President may share or lie about the results of their investigation at their discretion. No player may be investigated twice in the same game.
 			p.emphasis Call Special Election
 			p The President chooses any other player at the table to be the next Presidential Candidate. Any player can become President—even players that are term-limited. The new President nominates an eligible player as Chancellor Candidate and the Election proceeds as usual.
 			p.emphasis A Special Election does not skip any players. After a Special Election, the President placard returns to the right of the President who enacted the Special Election.
@@ -84,16 +81,30 @@ block content
 			p.emphasis Policy Peek
 			p After selecting the Policy deck, the President sees the top three tiles.
 			p.emphasis Execution
-			p The President executes one player by selecting them. If that player is Hitler, the game ends in a Liberal victory. If the executed player is not Hitler, the table should not learn whether a Fascist or a Liberal has been killed; players must try to work out for themselves the new table balance. Executed players are removed from the game and may not chat, vote, or run for office.
+			p The President executes one player by selecting them. If that player is Hitler, the game ends in a Liberal victory. If the executed player is not Hitler, the table does not learn whether a Fascist or a Liberal has been killed; players must try to work out for themselves the new table balance. Executed players are removed from the game and may not chat, vote, or run for office.
 			h4.ui.header.centered VETO POWER
-			p The Veto Power is a special rule that comes into effect after five Fascist Policies have been enacted. For all Legislative Sessions after the fifth Fascist Policy is enacted, the Executive branch gains a permanent new ability to discard all three Policy tiles if both the Chancellor and President agree.
-			p The President draws three Policy tiles, discards one, and passes the remaining two to the Chancellor as usual. Then Chancellor selects one, and then both the President and Chancellor vote on whether or not to veto the results of this election in secret.  If so, both Policies are discarded and the President placard passes to the right as usual. If either do not consent to veto, the Policy is enacted.
+			p The Veto Power is a permanent special rule that comes into effect after five Fascist Policies have been enacted. For all Legislative Sessions after the fifth Fascist Policy is enacted, the Executive branch gains a permanent new ability to discard all three Policy tiles if both the Chancellor and President agree.
+			p The President draws three Policy tiles, discards one, and passes the remaining two to the Chancellor as usual. The Chancellor selects one, and then both the President and Chancellor vote on whether or not to veto the results of this election in secret. If so, both Policies are discarded and the President placard passes to the right as usual. If either the President or Chancellor doesn't agree to veto, the Policy passes.
 			p Each use of the Veto Power represents an inactive government and advances the Election Tracker by one.
-			h2.ui.header.centered STRATEGY NOTES
+			h2.ui.header.centered BASIC STRATEGY
 			ul
 				li <span class="emphasis">Everyone should claim to be a Liberal.</span> Since the Liberal team has a voting majority, it can easily shut out any player claiming to be a Fascist. As a Fascist, there is no advantage to outing yourself to the majority. Additionally, Liberals should usually tell the truth. Liberals are trying to figure out the game like a puzzle, so lying can put their team at a significant disadvantage.
 				li <span class="emphasis">If this is your first time playing Hitler, just remember: be as Liberal as possible.</span> Enact Liberal Policies. Vote for Liberal governments. Kiss babies. Trust your fellow Fascists to create opportunities for you to enact Liberal Policies and to advance Fascism on their turns. The Fascists win by subtly manipulating the table and waiting for the right cover to enact Fascist Policies, not by overtly playing as evil.
 				li <span class="emphasis">Liberals frequently benefit from slowing play down and discussing the available information. Fascists frequently benefit from rushing votes and creating confusion.
-				li <span class="emphasis">Fascists most often win by electing Hitler, not by enacting six Policies!</span> Electing Hitler isn’t an optional or secondary win condition, it’s the core of a successful Fascist strategy. Hitler should always play as a Liberal, and should generally avoid lying or getting into fights and disagreements with other players. When the time comes, Hitler needs the liberal's trust to get elected. Even if Hitler isn’t ultimately elected, the distrust sown among Liberals is key to getting Fascists elected late in the game.
+				li <span class="emphasis">Fascists most often win by electing Hitler, not by enacting six Policies!</span> Electing Hitler isn’t an optional or secondary win condition, it’s the core of a successful Fascist strategy. Hitler should always play as a Liberal, and should generally avoid lying or getting into fights and disagreements with other players. When the time comes, Hitler needs the Liberal's trust to get elected. Even if Hitler isn’t ultimately elected, the distrust sown among Liberals is key to getting Fascists elected late in the game.
 				li <span class="emphasis">Ask other players to explain why they took an action.</span> This is especially important with Presidential Powers—in fact, ask ahead of time whom a candidate is thinking of investigating/appointing/assassinating.
-				li <span class="emphasis">If a Fascist Policy comes up, there are only three possible culprits: The President, the Chancellor, or the Policy Deck.</span> Try to figure out who (or what!) put you in this position. 
+				li <span class="emphasis">If a Fascist Policy comes up, there are only three possible culprits: The President, the Chancellor, or the Policy Deck.</span> Try to figure out who or what put you in this position.
+			h2.ui.header.centered GLOSSARY AND STRATEGIES
+			p This part contains definitions for common acronyms/terms and also some commonly seen strategies. You may skip this part for now and come back later once you've got hang of the game.
+			ul
+				li <span class="emphasis">Order</span> During the first rounds of the game, Liberals should try to get as many players elected in the government as possible. In a 5-player game, the first President should pick the fourth player as his Chancellor and the second President pick the fifth player so that everyone gets in the government at least once. As another example, in a 6-player game the picks should be 14, 25, and 36 (1 picking 4, 2 picking 5, 3 picking 6). In a 7-player game, the picks should be 15, 26, 37.
+				li <span class="emphasis">Blue/Red President (BP/RP)</span> Red Presidents (RP) are Presidents who claimed to get three Fascist cards. Blue Presidents (BP) are those who passed along Liberal Policies to the Chancellor. Blue Presidents who didn't have a choice to pass along two Fascist Policies to the Chancellor are sometimes called Semi-Blue Presidents (Semi-BP). Blue Chancellors (BC) are Chancellors who picked a Liberal Policy when they could have picked a Fascist one.
+				li <span class="emphasis">Conflict (conf)</span> Two players can be in conflict for different reasons, like claiming that you saw different Policies during the Legislative Session or investigating somebody and claiming he's a Fascist.
+				li <span class="emphasis">Freeze</span> Players can decide to "freeze" a particular player, meaning that they will not vote to elect that player into government. Usually, people in conflicts are frozen, and sometimes also Red Presidents depending on the circumstances.
+				li <span class="emphasis">Hitler Zone (HZ)</span> The game enters into so-called "Hitler Zone" when 3 Fascist Policies are enacted and there is a risk of electing Hitler that would mean losing the game for Liberals.
+				li <span class="emphasis">Force</span> When a President gets two Liberal and one Fascist Policy (shorthand: RBB) and decide to pass along two Liberal Policies giving the Chancellor no option to pick - that's called forcing. A Liberal should force, but Hitlers that don't know who the other fascists are might sometimes try passing along one Fascist and one Liberal Policy to see if the Chancellor picks the Fascist Policy, signalling the Hitler that they are a Fascist.
+				li <span class="emphasis">Gunpoint (GP)</span> A confirmed Liberal President can pick a player that is in conflict (Hitler usually does not conflict to remain unsuspicious) when the next Presidental Power is the execution. The picked player is forced to pick a Liberal Policy in case he has a choice unless he wants to get shot.
+				li <span class="emphasis">Powerplay (PP)</span> Powerplay is when you nominate the next President as a Chancellor, effectively letting him be in the government for two rounds in a row unless the proposal is denied. This should usually be avoided in the early game.
+				li <span class="emphasis">Double dip</span> When a single player conflicts with two players using the investigation power. How it works is that the President gives two Fascist tiles while lying that he gave the Chancellor a choice. They both get frozen, but the President first gets to investigate another player. He investigates a Liberal and claims he investigated a Fascist. So he effectively froze two Liberals with him.
+				li <span class="emphasis">Double ditch</span> When both the President and Chancellor are Fascists and they both ditch (discard, burn, drop etc.) a Liberal card.
+				li <span class="emphasis">Cucu</span> Cucu is a name for an advanced strategy that comes into play when the investigation power comes into play. This strategy is only valid before Hitler Zone. When a President enacts a Fascist Policy, he should investigate the player two spots ahead of him. If the investigated player is claimed to be a Liberal, he should pick the player who investigated him once he becomes a President. If a conflict happens, everyone can be sure that the Chancellor is a Fascist because he claimed that the President was a Liberal (meaning that he couldn't lie). That forces Fascists into playing Liberal cards. There is also another strategy related to this that is named pre-cucu. That strategy suggests that the next President after the investigation should pick the investigated player.


### PR DESCRIPTION
Right now, to learn how to play Secret Hitler you have to read a really long rules page, so I tried to make it a bit shorter and more organized by removing duplicate information.

The current rules page still had a part from the rules PDF in it that is not important when playing the online version of the game ("Why are there secret role and party membership cards?"), so I removed that part to make the rules shorter.

Also, another issue is that new players don't know any strategies when they just start playing and sometimes get yelled at for not following "order" etc. New players don't know where to read about all the commonly used terms and strategies, so, I added a "Glossary and Strategies" section so that players who already got hang of the game could read about all the common strategies in a single place.