### PR TITLE
Add Links to Stickies (also adds Emotes by extension)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"react-custom-scrollbars": "^4.2.1",
 		"react-dom": "^16.1.1",
 		"react-dropzone": "^4.2.8",
+		"react-linkify": "^0.2.2",
 		"react-redux": "^5.0.6",
 		"redux": "^3.7.2",
 		"redux-devtools": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -97,9 +97,11 @@
 	},
 	"scripts": {
 		"dev": "npm-run-all --parallel db server start",
+		"dev-docker": "npm-run-all --parallel db-docker server start",
 		"test": "jest __test__",
 		"test-watch": "jest --watch __test__",
 		"db": "mongod --dbpath data --port 15726",
+		"db-docker": "docker run -it --rm -p 15726:15726 -v \"$(PWD)/data\":/data/db --name Secret-Hitler-Dev-MongoDB mongo:latest --port 15726",
 		"build": "webpack --config webpack/webpack.config.prod --mode production",
 		"server": "nodemon bin/dev",
 		"start": "webpack --watch --config webpack/webpack.config.dev --mode development"

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -294,14 +294,14 @@ class Gamechat extends React.Component {
 						((chat.gameChat || chat.isClaim) && (chatFilter === 'Game' || chatFilter === 'All')) ||
 						(!chat.gameChat && chatFilter !== 'Game' && chatFilter !== 'No observer chat')
 				)
-        .map((chat, i) => {
+				.map((chat, i) => {
 					const playerListPlayer = Object.keys(userList).length ? userList.list.find(player => player.userName === chat.userName) : undefined;
 					const isMod = playerListPlayer
 						? ADMINS.includes(playerListPlayer.userName) || EDITORS.includes(playerListPlayer.userName) || MODERATORS.includes(playerListPlayer.userName)
 						: false;
-          const chatContents = processEmotes(chat.chat, isMod);
-          const isSeated = seatedUserNames.includes(chat.userName);
-          const isGreenText = /^>/i.test(chatContents[0]);
+					const chatContents = processEmotes(chat.chat, isMod);
+					const isSeated = seatedUserNames.includes(chat.userName);
+					const isGreenText = /^>/i.test(chatContents[0]);
 					let w;
 					let l;
 
@@ -389,7 +389,7 @@ class Gamechat extends React.Component {
 																ADMINS.includes(playerListPlayer.userName) ||
 																EDITORS.includes(playerListPlayer.userName)
 															) || !(gameSettings && gameSettings.disableSeasonal)
-														)}`
+													  )}`
 													: 'chat-user'
 										: 'chat-user'
 								}
@@ -419,7 +419,7 @@ class Gamechat extends React.Component {
 										? isBlind
 											? `${
 													gameInfo.general.replacementNames[gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName)]
-												} {${gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName) + 1}}`
+											  } {${gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName) + 1}}`
 											: `${chat.userName} {${gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName) + 1}}`
 										: chat.userName
 									: isBlind ? '?' : chat.userName}

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -294,14 +294,14 @@ class Gamechat extends React.Component {
 						((chat.gameChat || chat.isClaim) && (chatFilter === 'Game' || chatFilter === 'All')) ||
 						(!chat.gameChat && chatFilter !== 'Game' && chatFilter !== 'No observer chat')
 				)
-				.map((chat, i) => {
-					const chatContents = processEmotes(chat.chat);
-					const isSeated = seatedUserNames.includes(chat.userName);
+        .map((chat, i) => {
 					const playerListPlayer = Object.keys(userList).length ? userList.list.find(player => player.userName === chat.userName) : undefined;
-					const isGreenText = /^>/i.test(chatContents[0]);
 					const isMod = playerListPlayer
 						? ADMINS.includes(playerListPlayer.userName) || EDITORS.includes(playerListPlayer.userName) || MODERATORS.includes(playerListPlayer.userName)
 						: false;
+          const chatContents = processEmotes(chat.chat, isMod);
+          const isSeated = seatedUserNames.includes(chat.userName);
+          const isGreenText = /^>/i.test(chatContents[0]);
 					let w;
 					let l;
 
@@ -365,7 +365,7 @@ class Gamechat extends React.Component {
 							<span className="chat-user broadcast">
 								{this.handleTimestamps(chat.timestamp)} {`${chat.userName}: `}{' '}
 							</span>
-							<span className="broadcast-chat">{processEmotes(chat.chat)}</span>
+							<span className="broadcast-chat">{processEmotes(chat.chat, true)}</span>
 						</div>
 					) : (
 						<div className="item" key={i}>

--- a/src/frontend-scripts/components/section-right/Generalchat.jsx
+++ b/src/frontend-scripts/components/section-right/Generalchat.jsx
@@ -141,10 +141,11 @@ export default class Generalchat extends React.Component {
 		return generalChats.list
 			? generalChats.list.map((chat, i) => {
 					const { gameSettings } = userInfo;
-					const isMod = MODERATORS.includes(chat.userName) ||
-																 EDITORS.includes(chat.userName) ||
-																 ADMINS.includes(chat.userName) ||
-																 chat.userName.substring(0, 11) == '[BROADCAST]';
+					const isMod =
+						MODERATORS.includes(chat.userName) ||
+						EDITORS.includes(chat.userName) ||
+						ADMINS.includes(chat.userName) ||
+						chat.userName.substring(0, 11) == '[BROADCAST]';
 					const userClasses = classnames(
 						{
 							[chat.color]:
@@ -181,7 +182,7 @@ export default class Generalchat extends React.Component {
 							<span className={chat.isBroadcast ? 'broadcast-chat' : /^>/i.test(chat.chat) ? 'greentext' : ''}>{processEmotes(chat.chat, isMod)}</span>
 						</div>
 					);
-				})
+			  })
 			: null;
 	}
 

--- a/src/frontend-scripts/components/section-right/Generalchat.jsx
+++ b/src/frontend-scripts/components/section-right/Generalchat.jsx
@@ -141,6 +141,10 @@ export default class Generalchat extends React.Component {
 		return generalChats.list
 			? generalChats.list.map((chat, i) => {
 					const { gameSettings } = userInfo;
+					const isMod = MODERATORS.includes(chat.userName) ||
+																 EDITORS.includes(chat.userName) ||
+																 ADMINS.includes(chat.userName) ||
+																 chat.userName.substring(0, 11) == '[BROADCAST]';
 					const userClasses = classnames(
 						{
 							[chat.color]:
@@ -174,7 +178,7 @@ export default class Generalchat extends React.Component {
 									{`${chat.userName}: `}
 								</a>
 							</span>
-							<span className={chat.isBroadcast ? 'broadcast-chat' : /^>/i.test(chat.chat) ? 'greentext' : ''}>{processEmotes(chat.chat)}</span>
+							<span className={chat.isBroadcast ? 'broadcast-chat' : /^>/i.test(chat.chat) ? 'greentext' : ''}>{processEmotes(chat.chat, isMod)}</span>
 						</div>
 					);
 				})
@@ -191,7 +195,7 @@ export default class Generalchat extends React.Component {
 				<div className="sticky">
 					<span>
 						<span>Sticky: </span>
-						{this.props.generalChats.sticky}
+						{processEmotes(this.props.generalChats.sticky, true)}
 					</span>
 					<i className="remove icon" onClick={dismissSticky} />
 				</div>

--- a/src/frontend-scripts/emotes.js
+++ b/src/frontend-scripts/emotes.js
@@ -1,5 +1,6 @@
 import React from 'react'; // eslint-disable-line
 import { Button, Popup } from 'semantic-ui-react';
+import Linkify from 'react-linkify';
 
 export const allEmotes = [
 	'BangBang',
@@ -68,7 +69,7 @@ export function renderEmotesButton(handleInsertEmote) {
 	);
 }
 
-export function processEmotes(input) {
+export function processEmotes(input, isMod) {
 	if (typeof input !== 'string') {
 		return input;
 	}
@@ -125,5 +126,8 @@ export function processEmotes(input) {
 			formatedMsg.push(word, ' ');
 		}
 	});
+	if (isMod) {
+		return <Linkify properties={{ target: '_blank', title: 'External Link', style: { color: 'inherit', textDecoration: 'underline' } }}>{formatedMsg}</Linkify>;
+	}
 	return formatedMsg;
 }

--- a/src/scss/rightsidebar.scss
+++ b/src/scss/rightsidebar.scss
@@ -299,6 +299,13 @@
 					cursor: pointer;
 					margin: 0 3px;
 				}
+				a.shio-link {
+					color: #f4f439 !important;
+					text-decoration: underline !important;
+					&:hover {
+						color: #608cb3 !important;
+					}
+				}
 			}
 		}
 		.chats.discord {


### PR DESCRIPTION
Looking for this to close https://github.com/cozuya/secret-hitler/issues/715.

Integrated with the process emote functionality so as to add Emote functionality to the sticky too.  This also picks up the sh.io link colors/styles too.  Additionally I incorporated the ability for mods (and only mods) links to be turned into clickable links.  Everyone else is left with normal text.

Guidance on styling would be appreciated since I basically tried to keep the color unchanged when in the sticky so it's not too distracting.  Also, the name of `processEmotes` is a bit misleading since this is really adding formatting to all chat messages and this happens to include emotes.

<img width="362" alt="example" src="https://user-images.githubusercontent.com/6432753/37870569-0f86faca-2f9f-11e8-8ef2-824acce09cda.png">
