### PR TITLE
AEM color fixes

### DIFF
--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -1399,15 +1399,10 @@ module.exports.handleNewGeneralChat = (socket, passport, data) => {
 		});
 	}
 
-	const seasonColor = user && user[`winsSeason${currentSeasonNumber}`] + user[`lossesSeason${currentSeasonNumber}`] > 49 ? PLAYERCOLORS(user, true) : '';
-	const color = user && user.wins + user.losses > 49 ? PLAYERCOLORS(user) : '';
-
 	if (user.wins > 0 || user.losses > 0) {
 		generalChatCount++;
 		const newChat = {
 			time: new Date(),
-			color,
-			seasonColor,
 			chat: data.chat,
 			userName: passport.user
 		};

--- a/src/frontend-scripts/components/section-main/DisplayLobbies.jsx
+++ b/src/frontend-scripts/components/section-main/DisplayLobbies.jsx
@@ -224,7 +224,7 @@ const DisplayLobbies = props => {
 		players.forEach(player => {
 			const classes =
 				player.wins + player.losses > 49
-					? `player-small-cardback ${PLAYERCOLORS(player, !(gameSettings && gameSettings.disableSeasonal))}`
+					? PLAYERCOLORS(player, !(gameSettings && gameSettings.disableSeasonal), 'player-small-cardback')
 					: 'player-small-cardback';
 
 			if (player.customCardback && (!userInfo.userName || !(userInfo.userName && userInfo.gameSettings && userInfo.gameSettings.disablePlayerCardbacks))) {

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import $ from 'jquery';
-import { PLAYERCOLORS, MODERATORS, ADMINS, EDITORS, CURRENTSEASONNUMBER } from '../../constants';
+import { PLAYERCOLORS, MODERATORS, ADMINS, EDITORS, CONTRIBUTORS, CURRENTSEASONNUMBER } from '../../constants';
 import { loadReplay, toggleNotes, updateUser } from '../../actions/actions';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
@@ -246,7 +246,7 @@ class Gamechat extends React.Component {
 			};
 		}
 
-		if (!userName && !user) {
+		if (!user) {
 			return {
 				isDisabled: true,
 				placeholder: 'Please reload...'
@@ -378,13 +378,6 @@ class Gamechat extends React.Component {
 					const chatContents = processEmotes(chat.chat, isMod);
 					const isSeated = seatedUserNames.includes(chat.userName);
 					const isGreenText = /^>/i.test(chatContents[0]);
-					let w;
-					let l;
-
-					if (playerListPlayer) {
-						w = !(gameSettings && gameSettings.disableSeasonal) && !isMod ? playerListPlayer[`winsSeason${CURRENTSEASONNUMBER}`] : playerListPlayer.wins;
-						l = !(gameSettings && gameSettings.disableSeasonal) && !isMod ? playerListPlayer[`lossesSeason${CURRENTSEASONNUMBER}`] : playerListPlayer.losses;
-					}
 
 					return chat.gameChat ? (
 						<div className={chat.chat[1] && chat.chat[1].type ? `item gamechat ${chat.chat[1].type}` : 'item gamechat'} key={i}>
@@ -456,22 +449,9 @@ class Gamechat extends React.Component {
 								renderPreviousSeasonAward(chat.previousSeasonAward)}
 							<span
 								className={
-									playerListPlayer
-										? gameSettings && gameSettings.disablePlayerColorsInChat
-											? 'chat-user'
-											: isBlind
-												? 'chat-user'
-												: w + l > 49
-													? `chat-user ${PLAYERCOLORS(
-															playerListPlayer,
-															!(
-																MODERATORS.includes(playerListPlayer.userName) ||
-																ADMINS.includes(playerListPlayer.userName) ||
-																EDITORS.includes(playerListPlayer.userName)
-															) || !(gameSettings && gameSettings.disableSeasonal)
-														)}`
-													: 'chat-user'
-										: 'chat-user'
+									!playerListPlayer || (gameSettings && gameSettings.disablePlayerColorsInChat) || isBlind
+										? 'chat-user'
+										: PLAYERCOLORS(playerListPlayer, !(gameSettings && gameSettings.disableSeasonal), 'chat-user')
 								}
 							>
 								{isReplay || isSeated ? (

--- a/src/frontend-scripts/components/section-main/Players.jsx
+++ b/src/frontend-scripts/components/section-main/Players.jsx
@@ -258,8 +258,8 @@ class Players extends React.Component {
 						classes = `${classes} isDead`;
 					}
 
-					if (user && w + l > 49 && !isBlind) {
-						classes = `${classes} ${PLAYERCOLORS(user, !(gameSettings && gameSettings.disableSeasonal))}`;
+					if (user && !isBlind) {
+						classes = `${classes} ${PLAYERCOLORS(user, !(gameSettings && gameSettings.disableSeasonal), '')}`;
 					}
 
 					return classes;

--- a/src/frontend-scripts/components/section-right/Generalchat.jsx
+++ b/src/frontend-scripts/components/section-right/Generalchat.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import classnames from 'classnames';
-import { MODERATORS, EDITORS, ADMINS } from '../../constants';
+import { MODERATORS, EDITORS, ADMINS, PLAYERCOLORS } from '../../constants';
 import PropTypes from 'prop-types';
 import { renderEmotesButton, processEmotes } from '../../emotes';
 import { Scrollbars } from 'react-custom-scrollbars';
@@ -133,7 +132,7 @@ export default class Generalchat extends React.Component {
 
 	renderChats() {
 		let timestamp;
-		const { userInfo, generalChats } = this.props;
+		const { userInfo, userList, generalChats } = this.props;
 		const time = new Date().getTime();
 
 		/**
@@ -153,17 +152,11 @@ export default class Generalchat extends React.Component {
 						EDITORS.includes(chat.userName) ||
 						ADMINS.includes(chat.userName) ||
 						chat.userName.substring(0, 11) == '[BROADCAST]';
-					const userClasses = classnames(
-						{
-							[chat.color]:
-								MODERATORS.includes(chat.userName) ||
-								EDITORS.includes(chat.userName) ||
-								ADMINS.includes(chat.userName) ||
-								(!(gameSettings && gameSettings.disablePlayerColorsInChat) && (gameSettings && gameSettings.disableSeasonal)),
-							[chat.seasonColor]: !(gameSettings && gameSettings.disablePlayerColorsInChat) && !(gameSettings && gameSettings.disableSeasonal)
-						},
-						'chat-user'
-					);
+					const user = chat.userName ? userList.list.find(player => player.userName === chat.userName) : undefined;
+					const userClasses =
+						!user || (gameSettings && gameSettings.disablePlayerColorsInChat)
+							? 'chat-user'
+							: PLAYERCOLORS(user, !(gameSettings && gameSettings.disableSeasonal), 'chat-user');
 
 					if (userInfo.gameSettings && userInfo.gameSettings.enableTimestamps) {
 						timestamp = <span className="timestamp">{moment(chat.time).format('HH:mm')} </span>;
@@ -192,7 +185,7 @@ export default class Generalchat extends React.Component {
 							<span className={chat.isBroadcast ? 'broadcast-chat' : /^>/i.test(chat.chat) ? 'greentext' : ''}>{processEmotes(chat.chat, isMod)}</span>
 						</div>
 					);
-			  })
+				})
 			: null;
 	}
 

--- a/src/frontend-scripts/components/section-right/Playerlist.jsx
+++ b/src/frontend-scripts/components/section-right/Playerlist.jsx
@@ -258,12 +258,11 @@ class Playerlist extends React.Component {
 						MODERATORS.includes(user.userName) ||
 						CONTRIBUTORS.includes(user.userName)
 							? cn(
-									PLAYERCOLORS(user, !(gameSettings && gameSettings.disableSeasonal)),
+									PLAYERCOLORS(user, !(gameSettings && gameSettings.disableSeasonal), 'username'),
 									{ blacklisted: gameSettings && gameSettings.blacklist.includes(user.userName) },
 									{ unclickable: !this.props.isUserClickable },
-									{ clickable: this.props.isUserClickable },
-									'username'
-							  )
+									{ clickable: this.props.isUserClickable }
+							)
 							: cn({ blacklisted: gameSettings && gameSettings.blacklist.includes(user.userName) }, 'username');
 					const renderStatus = () => {
 						const status = user.status;

--- a/src/frontend-scripts/constants.js
+++ b/src/frontend-scripts/constants.js
@@ -46,37 +46,46 @@ module.exports.CURRENTSEASONNUMBER = CURRENTSEASONNUMBER;
 /**
  * @param {object} user - user from userlist.
  * @param {boolean} isSeasonal - whether or not to display seasonal colors.
+ * @param {string} defaultClass - the default class
  * @return {string} list of classes for colors.
  */
-module.exports.PLAYERCOLORS = (user, isSeasonal) => {
-	const w = isSeasonal ? user[`winsSeason${CURRENTSEASONNUMBER}`] : user.wins;
-	const l = isSeasonal ? user[`lossesSeason${CURRENTSEASONNUMBER}`] : user.losses;
+module.exports.PLAYERCOLORS = (user, isSeasonal, defaultClass) => {
+	if (MODERATORS.includes(user.userName) ||
+		ADMINS.includes(user.userName) ||
+		EDITORS.includes(user.userName) ||
+		CONTRIBUTORS.includes(user.userName)) {
+		return cn(defaultClass, {
+			admin: ADMINS.includes(user.userName),
+			moderatorcolor: MODERATORS.includes(user.userName),
+			editorcolor: EDITORS.includes(user.userName),
+			contributer: CONTRIBUTORS.includes(user.userName),
+			cbell: user.userName === 'cbell',
+			max: user.userName === 'Max',
+			dfinn: user.userName === 'DFinn',
+			faaiz: user.userName === 'Faaiz1999',
+			invidia: user.userName === 'Invidia',
+			thejuststopo: user.userName === 'TheJustStopO'
+		});
+	} else {
+		const w = isSeasonal ? user[`winsSeason${CURRENTSEASONNUMBER}`] : user.wins;
+		const l = isSeasonal ? user[`lossesSeason${CURRENTSEASONNUMBER}`] : user.losses;
 
-	return cn({
-		admin: ADMINS.includes(user.userName),
-		moderatorcolor: MODERATORS.includes(user.userName),
-		editorcolor: EDITORS.includes(user.userName),
-		experienced1: w + l > 49,
-		experienced2: w + l > 99,
-		experienced3: w + l > 199,
-		experienced4: w + l > 299,
-		experienced5: w + l > 499,
-		onfire1: w / (w + l) > 0.52,
-		onfire2: w / (w + l) > 0.54,
-		onfire3: w / (w + l) > 0.56,
-		onfire4: w / (w + l) > 0.58,
-		onfire5: w / (w + l) > 0.6,
-		onfire6: w / (w + l) > 0.62,
-		onfire7: w / (w + l) > 0.64,
-		onfire8: w / (w + l) > 0.66,
-		onfire9: w / (w + l) > 0.68,
-		onfire10: w / (w + l) > 0.7,
-		contributer: CONTRIBUTORS.includes(user.userName),
-		cbell: user.userName === 'cbell',
-		max: user.userName === 'Max',
-		dfinn: user.userName === 'DFinn',
-		faaiz: user.userName === 'Faaiz1999',
-		invidia: user.userName === 'Invidia',
-		thejuststopo: user.userName === 'TheJustStopO'
-	});
+		return cn(defaultClass, {
+			experienced1: w + l > 49,
+			experienced2: w + l > 99,
+			experienced3: w + l > 199,
+			experienced4: w + l > 299,
+			experienced5: w + l > 499,
+			onfire1: w / (w + l) > 0.52,
+			onfire2: w / (w + l) > 0.54,
+			onfire3: w / (w + l) > 0.56,
+			onfire4: w / (w + l) > 0.58,
+			onfire5: w / (w + l) > 0.6,
+			onfire6: w / (w + l) > 0.62,
+			onfire7: w / (w + l) > 0.64,
+			onfire8: w / (w + l) > 0.66,
+			onfire9: w / (w + l) > 0.68,
+			onfire10: w / (w + l) > 0.7,
+		});
+	}
 };


### PR DESCRIPTION
AEM colors have been broken since seasonal mode was implemented. This patch reduces the redundancy of the color code and fixes AEM colors in general chat, game chat, game lobby displays, game player cards and the online players list. All of these had slightly different implementations.

Unfortunately, its possible the current state of this patch also breaks seasonal colors. Tested as best I could, but there are no good tools to test seasonal issues in dev. I am fairly confident that I did not break seasonal colors, I just cant be sure. Leaving if this makes it into the `0.13.3` patch up to you.

*And for the record, did not fix this just to show off my fancy orange name. Not entirely anyway.*