### PR TITLE
Elo changes are now individualized

### DIFF
--- a/routes/socket/game/end-game.js
+++ b/routes/socket/game/end-game.js
@@ -148,42 +148,34 @@ module.exports.completeGame = (game, winningTeamName) => {
 				const isTournamentFinalGame = game.general.isTourny && game.general.tournyInfo.round === 2;
 
 				const eloAdjustments = rateEloGame(game, results, winningPlayerNames);
-				const adjustmentChat = {
-					gameChat: true,
-					timestamp: new Date(),
-					chat: [
-						{
-							text: winningTeamName === 'fascist' ? 'Fascists' : 'Liberals',
-							type: winningTeamName === 'fascist' ? 'fascist' : 'liberal'
-						},
-						{
-							text: ' gain '
-						},
-						{
-							text: eloAdjustments.winningPlayerAdjustment.toFixed(0),
-							type: 'player'
-						},
-						{
-							text: ' elo. '
-						},
-						{
-							text: winningTeamName === 'fascist' ? 'Liberals' : 'Fascists',
-							type: winningTeamName === 'fascist' ? 'liberal' : 'fascist'
-						},
-						{
-							text: ' lose '
-						},
-						{
-							text: -1 * eloAdjustments.losingPlayerAdjustment.toFixed(0),
-							type: 'player'
-						},
-						{
-							text: ' elo.'
-						}
-					]
-				};
 
 				seatedPlayers.forEach(player => {
+					const adjustmentChat = {
+						gameChat: true,
+						timestamp: new Date(),
+						chat: [
+							{
+								text: 'You'
+							},
+							{
+								text: (eloAdjustments[player.userName][0] > 0) ? ' gain ' : ' lose '
+							},
+							{
+								text: Math.abs(eloAdjustments[player.userName][0]).toFixed(1),
+								type: 'player'
+							},
+							{
+								text: ' elo and '
+							},
+							{
+								text: Math.abs(eloAdjustments[player.userName][1]).toFixed(1),
+								type: 'player'
+							},
+							{
+								text: ' seasonal elo.'
+							}
+						]
+					};
 					player.gameChats.push(adjustmentChat);
 				});
 

--- a/routes/socket/game/end-game.js
+++ b/routes/socket/game/end-game.js
@@ -161,14 +161,14 @@ module.exports.completeGame = (game, winningTeamName) => {
 								text: (eloAdjustments[player.userName][0] > 0) ? ' gain ' : ' lose '
 							},
 							{
-								text: Math.abs(eloAdjustments[player.userName][0]).toFixed(1),
+								text: Math.abs(eloAdjustments[player.userName].change).toFixed(1),
 								type: 'player'
 							},
 							{
 								text: ' elo and '
 							},
 							{
-								text: Math.abs(eloAdjustments[player.userName][1]).toFixed(1),
+								text: Math.abs(eloAdjustments[player.userName].changeSeason).toFixed(1),
 								type: 'player'
 							},
 							{
@@ -178,8 +178,6 @@ module.exports.completeGame = (game, winningTeamName) => {
 					};
 					player.gameChats.push(adjustmentChat);
 				});
-
-				game.private.unSeatedGameChats.push(adjustmentChat);
 
 				sendInProgressGameUpdate(game);
 

--- a/routes/socket/util.js
+++ b/routes/socket/util.js
@@ -157,10 +157,10 @@ module.exports.rateEloGame = (game, accounts, winningPlayerNames) => {
 			changeSeason = pSeason * loseFactor;
 		}
 
-		account.eloOverall = account.eloOverall + change;
-		account.eloSeason = account.eloSeason + changeSeason;
+		account.eloOverall = eloOverall + change;
+		account.eloSeason = eloSeason + changeSeason;
 
-		eloAdjustment[account.username] = {change, changeSeason};
+		eloAdjustment[account.username] = { change, changeSeason };
 
 		account.save();
 	});

--- a/routes/socket/util.js
+++ b/routes/socket/util.js
@@ -118,7 +118,11 @@ module.exports.rateEloGame = (game, accounts, winningPlayerNames) => {
 	if (game.gameState.isCompleted === 'liberal') {
 		averageRatingWinners += libWinAdjust[game.private.seatedPlayers.length];
 		averageRatingWinnersSeason += libWinAdjust[game.private.seatedPlayers.length];
+		averageRatingLosers -= libWinAdjust[game.private.seatedPlayers.length];
+		averageRatingLosersSeason -= libWinAdjust[game.private.seatedPlayers.length];
 	} else {
+		averageRatingWinners -= libWinAdjust[game.private.seatedPlayers.length];
+		averageRatingWinnersSeason -= libWinAdjust[game.private.seatedPlayers.length];
 		averageRatingLosers += libWinAdjust[game.private.seatedPlayers.length];
 		averageRatingLosersSeason += libWinAdjust[game.private.seatedPlayers.length];
 	}


### PR DESCRIPTION
Instead of all players gaining/losing the same amount, their specific rating is compared against the opposing team to determine their gain/loss. This means higher rated players will lose more than lower rated players in the same game, and will also gain less.

This should discourage boosting. Without this change you can just play games with elo values far below your own, and the averaging gives you abnormally high gains. With this change, you are pulled towards their elo value.