### PR TITLE
ELO scripts for coz

### DIFF
--- a/scripts/rating/allGames.js
+++ b/scripts/rating/allGames.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+const Game = require('../../models/game'); // temp
+
+module.exports = async rate => {
+	try {
+		mongoose.Promise = global.Promise;
+		await mongoose.connect(`mongodb://localhost:15726/secret-hitler-app`);
+		const cursor = await Game.find({}, { chats: 0 }).cursor();
+		for (let game = await cursor.next(); game != null; game = await cursor.next()) {
+			// Ignore casual games
+			if (!game.casualGame) {
+				await rate(game);
+			}
+		}
+	} catch (error) {
+		console.error(error);
+	} finally {
+		await mongoose.disconnect();
+	}
+};

--- a/scripts/rating/clearRatings.js
+++ b/scripts/rating/clearRatings.js
@@ -1,0 +1,21 @@
+const Account = require('../../models/account'); // temp
+const mongoose = require('mongoose');
+
+async function clearRatings() {
+	try {
+		mongoose.Promise = global.Promise;
+		await mongoose.connect(`mongodb://localhost:15726/secret-hitler-app`);
+		await Account
+			.find()
+			.cursor()
+			.eachAsync(account => {
+				account.eloSeason = 1600;
+				account.eloOverall = 1600;
+				account.save();
+			});
+	} finally {
+		await mongoose.disconnect();
+	}
+}
+
+clearRatings();

--- a/scripts/rating/cozRatings.js
+++ b/scripts/rating/cozRatings.js
@@ -29,6 +29,10 @@ async function cozRatings() {
 		await Game.find({}, { chats: 0 })
 			.cursor()
 			.eachAsync(async game => {
+				// Ignore casual games
+				if (game.casualGame) {
+					return;
+				}
 				// Get the players
 				const winningPlayerNames = game.winningPlayers.map(player => player.userName);
 				const losingPlayerNames = game.losingPlayers.map(player => player.userName);

--- a/scripts/rating/cozRatings.js
+++ b/scripts/rating/cozRatings.js
@@ -43,7 +43,7 @@ async function rate(game) {
 	const losingPlayerAdjustment = -k * p / losingPlayerNames.length;
 	const winningPlayerAdjustmentSeason = k * pSeason / winningPlayerNames.length;
 	const losingPlayerAdjustmentSeason = -k * pSeason / losingPlayerNames.length;
-	// Apply the rating chaanges
+	// Apply the rating changes
 	for (let account of accounts) {
 		let eloOverall;
 		let eloSeason;

--- a/scripts/rating/cozRatings.js
+++ b/scripts/rating/cozRatings.js
@@ -1,0 +1,79 @@
+const Game = require('../../models/game'); // temp
+const Account = require('../../models/account'); // temp
+const mongoose = require('mongoose');
+const { CURRENTSEASONNUMBER } = require('../../src/frontend-scripts/constants');
+
+const winAdjust = {
+	5: -19.253,
+	6: 20.637,
+	7: -17.282,
+	8: 45.418,
+	9: -70.679,
+	10: -31.539
+};
+
+function avg(accounts, players, acsessor, fallback) {
+	return (
+		players.reduce(
+			(prev, curr) =>
+				acsessor(accounts.find(account => account.username === curr)) ? acsessor(accounts.find(account => account.username === curr)) + prev : fallback,
+			0
+		) / players.length
+	);
+}
+
+async function cozRatings() {
+	try {
+		mongoose.Promise = global.Promise;
+		await mongoose.connect(`mongodb://localhost:15726/secret-hitler-app`);
+		await Game.find({}, { chats: 0 })
+			.cursor()
+			.eachAsync(async game => {
+				// Get the players
+				const winningPlayerNames = game.winningPlayers.map(player => player.userName);
+				const losingPlayerNames = game.losingPlayers.map(player => player.userName);
+				const playerNames = winningPlayerNames.concat(losingPlayerNames);
+				// Then look up account information
+				let accounts = await Account.find({ username: { $in: playerNames } }, { eloOverall: 1, eloSeason: 1, username: 1 });
+				// Construct some basic statistics for each team
+				const b = (game.winningTeam === 'liberal') ? 1 : -1;
+				const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, 1600) + b * winAdjust[game.playerCount];
+				const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, 1600) - b * winAdjust[game.playerCount];
+				const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, 1600) + b * winAdjust[game.playerCount];
+				const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, 1600) - b * winAdjust[game.playerCount];
+				// Elo Formula
+				const k = 64;
+				const p = 1 / (1 + Math.pow(10, (averageRatingWinners - averageRatingLosers) / 400));
+				const pSeason = 1 / (1 + Math.pow(10, (averageRatingWinnersSeason - averageRatingLosersSeason) / 400));
+				// Calculate ratings deltas
+				const winningPlayerAdjustment = k * p / winningPlayerNames.length;
+				const losingPlayerAdjustment = -k * p / losingPlayerNames.length;
+				const winningPlayerAdjustmentSeason = k * pSeason / winningPlayerNames.length;
+				const losingPlayerAdjustmentSeason = -k * pSeason / losingPlayerNames.length;
+				// Apply the rating chaanges
+				for (let account of accounts) {
+					let eloOverall;
+					let eloSeason;
+
+					if (!account.eloOverall) {
+						eloOverall = 1600;
+						eloSeason = 1600;
+					} else {
+						eloOverall = account.eloOverall;
+						eloSeason = account.eloSeason;
+					}
+
+					account.eloOverall = winningPlayerNames.includes(account.username) ? eloOverall + winningPlayerAdjustment : eloOverall + losingPlayerAdjustment;
+					if (game.season === CURRENTSEASONNUMBER) {
+						account.eloSeason = winningPlayerNames.includes(account.username) ? eloSeason + winningPlayerAdjustmentSeason : eloSeason + losingPlayerAdjustmentSeason;
+					}
+
+					account.save();
+				}
+			});
+	} finally {
+		await mongoose.disconnect();
+	}
+}
+
+cozRatings();

--- a/scripts/rating/cozRatings.js
+++ b/scripts/rating/cozRatings.js
@@ -1,6 +1,5 @@
-const Game = require('../../models/game'); // temp
-const Account = require('../../models/account'); // temp
-const mongoose = require('mongoose');
+const AllGames = require('./allGames');
+const Account = require('../../models/account');
 const { CURRENTSEASONNUMBER } = require('../../src/frontend-scripts/constants');
 
 const winAdjust = {
@@ -22,62 +21,45 @@ function avg(accounts, players, acsessor, fallback) {
 	);
 }
 
-async function cozRatings() {
-	try {
-		mongoose.Promise = global.Promise;
-		await mongoose.connect(`mongodb://localhost:15726/secret-hitler-app`);
-		await Game.find({}, { chats: 0 })
-			.cursor()
-			.eachAsync(async game => {
-				// Ignore casual games
-				if (game.casualGame) {
-					return;
-				}
-				// Get the players
-				const winningPlayerNames = game.winningPlayers.map(player => player.userName);
-				const losingPlayerNames = game.losingPlayers.map(player => player.userName);
-				const playerNames = winningPlayerNames.concat(losingPlayerNames);
-				// Then look up account information
-				let accounts = await Account.find({ username: { $in: playerNames } }, { eloOverall: 1, eloSeason: 1, username: 1 });
-				// Construct some basic statistics for each team
-				const b = (game.winningTeam === 'liberal') ? 1 : -1;
-				const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, 1600) + b * winAdjust[game.playerCount];
-				const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, 1600) - b * winAdjust[game.playerCount];
-				const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, 1600) + b * winAdjust[game.playerCount];
-				const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, 1600) - b * winAdjust[game.playerCount];
-				// Elo Formula
-				const k = 64;
-				const p = 1 / (1 + Math.pow(10, (averageRatingWinners - averageRatingLosers) / 400));
-				const pSeason = 1 / (1 + Math.pow(10, (averageRatingWinnersSeason - averageRatingLosersSeason) / 400));
-				// Calculate ratings deltas
-				const winningPlayerAdjustment = k * p / winningPlayerNames.length;
-				const losingPlayerAdjustment = -k * p / losingPlayerNames.length;
-				const winningPlayerAdjustmentSeason = k * pSeason / winningPlayerNames.length;
-				const losingPlayerAdjustmentSeason = -k * pSeason / losingPlayerNames.length;
-				// Apply the rating chaanges
-				for (let account of accounts) {
-					let eloOverall;
-					let eloSeason;
-
-					if (!account.eloOverall) {
-						eloOverall = 1600;
-						eloSeason = 1600;
-					} else {
-						eloOverall = account.eloOverall;
-						eloSeason = account.eloSeason;
-					}
-
-					account.eloOverall = winningPlayerNames.includes(account.username) ? eloOverall + winningPlayerAdjustment : eloOverall + losingPlayerAdjustment;
-					if (game.season === CURRENTSEASONNUMBER) {
-						account.eloSeason = winningPlayerNames.includes(account.username) ? eloSeason + winningPlayerAdjustmentSeason : eloSeason + losingPlayerAdjustmentSeason;
-					}
-
-					account.save();
-				}
-			});
-	} finally {
-		await mongoose.disconnect();
+async function rate(game) {
+	// Get the players
+	const winningPlayerNames = game.winningPlayers.map(player => player.userName);
+	const losingPlayerNames = game.losingPlayers.map(player => player.userName);
+	const playerNames = winningPlayerNames.concat(losingPlayerNames);
+	// Then look up account information
+	let accounts = await Account.find({ username: { $in: playerNames } }, { eloOverall: 1, eloSeason: 1, username: 1 });
+	// Construct some basic statistics for each team
+	const b = game.winningTeam === 'liberal' ? 1 : -1;
+	const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, 1600) + b * winAdjust[game.playerCount];
+	const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, 1600) - b * winAdjust[game.playerCount];
+	const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, 1600) + b * winAdjust[game.playerCount];
+	const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, 1600) - b * winAdjust[game.playerCount];
+	// Elo Formula
+	const k = 64;
+	const p = 1 / (1 + Math.pow(10, (averageRatingWinners - averageRatingLosers) / 400));
+	const pSeason = 1 / (1 + Math.pow(10, (averageRatingWinnersSeason - averageRatingLosersSeason) / 400));
+	// Calculate ratings deltas
+	const winningPlayerAdjustment = k * p / winningPlayerNames.length;
+	const losingPlayerAdjustment = -k * p / losingPlayerNames.length;
+	const winningPlayerAdjustmentSeason = k * pSeason / winningPlayerNames.length;
+	const losingPlayerAdjustmentSeason = -k * pSeason / losingPlayerNames.length;
+	// Apply the rating chaanges
+	for (let account of accounts) {
+		let eloOverall;
+		let eloSeason;
+		if (!account.eloOverall) {
+			eloOverall = 1600;
+			eloSeason = 1600;
+		} else {
+			eloOverall = account.eloOverall;
+			eloSeason = account.eloSeason;
+		}
+		account.eloOverall = winningPlayerNames.includes(account.username) ? eloOverall + winningPlayerAdjustment : eloOverall + losingPlayerAdjustment;
+		if (game.season === CURRENTSEASONNUMBER) {
+			account.eloSeason = winningPlayerNames.includes(account.username) ? eloSeason + winningPlayerAdjustmentSeason : eloSeason + losingPlayerAdjustmentSeason;
+		}
+		await account.save();
 	}
 }
 
-cozRatings();
+AllGames(rate);

--- a/scripts/rating/hexRatings.js
+++ b/scripts/rating/hexRatings.js
@@ -1,0 +1,83 @@
+const Game = require('../../models/game'); // temp
+const Account = require('../../models/account'); // temp
+const mongoose = require('mongoose');
+const { CURRENTSEASONNUMBER } = require('../../src/frontend-scripts/constants');
+
+const winAdjust = {
+	5: -19.253,
+	6: 20.637,
+	7: -17.282,
+	8: 45.418,
+	9: -70.679,
+	10: -31.539
+};
+
+function avg(accounts, players, acsessor, fallback) {
+	return (
+		players.reduce(
+			(prev, curr) =>
+				acsessor(accounts.find(account => account.username === curr)) ? acsessor(accounts.find(account => account.username === curr)) + prev : fallback,
+			0
+		) / players.length
+	);
+}
+
+async function hexRatings() {
+	try {
+		mongoose.Promise = global.Promise;
+		await mongoose.connect(`mongodb://localhost:15726/secret-hitler-app`);
+		await Game.find({}, { chats: 0 })
+			.cursor()
+			.eachAsync(async game => {
+				// Get the players
+				const winningPlayerNames = game.winningPlayers.map(player => player.userName);
+				const losingPlayerNames = game.losingPlayers.map(player => player.userName);
+				const playerNames = winningPlayerNames.concat(losingPlayerNames);
+				// Then look up account information
+				let accounts = await Account.find({ username: { $in: playerNames } }, { eloOverall: 1, eloSeason: 1, username: 1 });
+				// Construct some basic statistics for each team
+				const b = (game.winningTeam === 'liberal') ? 1 : -1;
+				const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, 1600) + b * winAdjust[game.playerCount];
+				const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, 1600) - b * winAdjust[game.playerCount];
+				const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, 1600) + b * winAdjust[game.playerCount];
+				const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, 1600) - b * winAdjust[game.playerCount];
+				// Hexi's Elo constants
+				const k = 64;
+				const winFactor = k / winningPlayerNames.length;
+				const loseFactor = -k / losingPlayerNames.length;
+				// Apply the rating chaanges
+				for (let account of accounts) {
+					let eloOverall;
+					let eloSeason;
+
+					if (!account.eloOverall) {
+						eloOverall = 1600;
+						eloSeason = 1600;
+					} else {
+						eloOverall = account.eloOverall;
+						eloSeason = account.eloSeason;
+					}
+
+					const win = winningPlayerNames.includes(account.username);
+					if (win) {
+						const p = 1 / (1 + Math.pow(10, (eloOverall - averageRatingLosers) / 400));
+						const pSeason = 1 / (1 + Math.pow(10, (eloSeason - averageRatingLosersSeason) / 400));
+						change = p * winFactor;
+						changeSeason = pSeason * winFactor;
+					} else {
+						const p = 1 / (1 + Math.pow(10, (averageRatingWinners - eloOverall) / 400));
+						const pSeason = 1 / (1 + Math.pow(10, (averageRatingWinnersSeason - eloSeason) / 400));
+						change = p * loseFactor;
+						changeSeason = pSeason * loseFactor;
+					}
+					account.eloOverall = eloOverall + change;
+					account.eloSeason = eloSeason + changeSeason;
+					account.save();
+				}
+			});
+	} finally {
+		await mongoose.disconnect();
+	}
+}
+
+hexRatings();

--- a/scripts/rating/hexRatings.js
+++ b/scripts/rating/hexRatings.js
@@ -67,7 +67,7 @@ async function rate(game) {
 		if (game.season === CURRENTSEASONNUMBER) {
 			account.eloSeason = eloSeason + changeSeason;
 		}
-		account.save();
+		await account.save();
 	}
 }
 

--- a/scripts/rating/hexRatings.js
+++ b/scripts/rating/hexRatings.js
@@ -29,6 +29,10 @@ async function hexRatings() {
 		await Game.find({}, { chats: 0 })
 			.cursor()
 			.eachAsync(async game => {
+				// Ignore casual games
+				if (game.casualGame) {
+					return;
+				}
 				// Get the players
 				const winningPlayerNames = game.winningPlayers.map(player => player.userName);
 				const losingPlayerNames = game.losingPlayers.map(player => player.userName);

--- a/scripts/rating/hexRatings.js
+++ b/scripts/rating/hexRatings.js
@@ -1,6 +1,5 @@
-const Game = require('../../models/game'); // temp
-const Account = require('../../models/account'); // temp
-const mongoose = require('mongoose');
+const AllGames = require('./allGames');
+const Account = require('../../models/account');
 const { CURRENTSEASONNUMBER } = require('../../src/frontend-scripts/constants');
 
 const winAdjust = {
@@ -22,66 +21,54 @@ function avg(accounts, players, acsessor, fallback) {
 	);
 }
 
-async function hexRatings() {
-	try {
-		mongoose.Promise = global.Promise;
-		await mongoose.connect(`mongodb://localhost:15726/secret-hitler-app`);
-		await Game.find({}, { chats: 0 })
-			.cursor()
-			.eachAsync(async game => {
-				// Ignore casual games
-				if (game.casualGame) {
-					return;
-				}
-				// Get the players
-				const winningPlayerNames = game.winningPlayers.map(player => player.userName);
-				const losingPlayerNames = game.losingPlayers.map(player => player.userName);
-				const playerNames = winningPlayerNames.concat(losingPlayerNames);
-				// Then look up account information
-				let accounts = await Account.find({ username: { $in: playerNames } }, { eloOverall: 1, eloSeason: 1, username: 1 });
-				// Construct some basic statistics for each team
-				const b = (game.winningTeam === 'liberal') ? 1 : -1;
-				const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, 1600) + b * winAdjust[game.playerCount];
-				const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, 1600) - b * winAdjust[game.playerCount];
-				const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, 1600) + b * winAdjust[game.playerCount];
-				const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, 1600) - b * winAdjust[game.playerCount];
-				// Hexi's Elo constants
-				const k = 64;
-				const winFactor = k / winningPlayerNames.length;
-				const loseFactor = -k / losingPlayerNames.length;
-				// Apply the rating chaanges
-				for (let account of accounts) {
-					let eloOverall;
-					let eloSeason;
+async function rate(game) {
+	// Get the players
+	const winningPlayerNames = game.winningPlayers.map(player => player.userName);
+	const losingPlayerNames = game.losingPlayers.map(player => player.userName);
+	const playerNames = winningPlayerNames.concat(losingPlayerNames);
+	// Then look up account information
+	let accounts = await Account.find({ username: { $in: playerNames } }, { eloOverall: 1, eloSeason: 1, username: 1 });
+	// Construct some basic statistics for each team
+	const b = game.winningTeam === 'liberal' ? 1 : -1;
+	const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, 1600) + b * winAdjust[game.playerCount];
+	const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, 1600) - b * winAdjust[game.playerCount];
+	const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, 1600) + b * winAdjust[game.playerCount];
+	const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, 1600) - b * winAdjust[game.playerCount];
+	// Hexi's Elo constants
+	const k = 64;
+	const winFactor = k / winningPlayerNames.length;
+	const loseFactor = -k / losingPlayerNames.length;
+	// Apply the rating changes
+	for (let account of accounts) {
+		let eloOverall;
+		let eloSeason;
 
-					if (!account.eloOverall) {
-						eloOverall = 1600;
-						eloSeason = 1600;
-					} else {
-						eloOverall = account.eloOverall;
-						eloSeason = account.eloSeason;
-					}
+		if (!account.eloOverall) {
+			eloOverall = 1600;
+			eloSeason = 1600;
+		} else {
+			eloOverall = account.eloOverall;
+			eloSeason = account.eloSeason;
+		}
 
-					const win = winningPlayerNames.includes(account.username);
-					if (win) {
-						const p = 1 / (1 + Math.pow(10, (eloOverall - averageRatingLosers) / 400));
-						const pSeason = 1 / (1 + Math.pow(10, (eloSeason - averageRatingLosersSeason) / 400));
-						change = p * winFactor;
-						changeSeason = pSeason * winFactor;
-					} else {
-						const p = 1 / (1 + Math.pow(10, (averageRatingWinners - eloOverall) / 400));
-						const pSeason = 1 / (1 + Math.pow(10, (averageRatingWinnersSeason - eloSeason) / 400));
-						change = p * loseFactor;
-						changeSeason = pSeason * loseFactor;
-					}
-					account.eloOverall = eloOverall + change;
-					account.eloSeason = eloSeason + changeSeason;
-					account.save();
-				}
-			});
-	} finally {
-		await mongoose.disconnect();
+		const win = winningPlayerNames.includes(account.username);
+		if (win) {
+			const p = 1 / (1 + Math.pow(10, (eloOverall - averageRatingLosers) / 400));
+			const pSeason = 1 / (1 + Math.pow(10, (eloSeason - averageRatingLosersSeason) / 400));
+			change = p * winFactor;
+			changeSeason = pSeason * winFactor;
+		} else {
+			const p = 1 / (1 + Math.pow(10, (averageRatingWinners - eloOverall) / 400));
+			const pSeason = 1 / (1 + Math.pow(10, (averageRatingWinnersSeason - eloSeason) / 400));
+			change = p * loseFactor;
+			changeSeason = pSeason * loseFactor;
+		}
+		account.eloOverall = eloOverall + change;
+		if (game.season === CURRENTSEASONNUMBER) {
+			account.eloSeason = eloSeason + changeSeason;
+		}
+		account.save();
 	}
 }
 
-hexRatings();
+AllGames(rate);

--- a/scripts/rating/nthRatings.js
+++ b/scripts/rating/nthRatings.js
@@ -1,6 +1,5 @@
-const Game = require('../../models/game'); // temp
-const Account = require('../../models/account'); // temp
-const mongoose = require('mongoose');
+const AllGames = require('./allGames');
+const Account = require('../../models/account');
 const { CURRENTSEASONNUMBER } = require('../../src/frontend-scripts/constants');
 
 const winAdjust = {
@@ -22,62 +21,48 @@ function avg(accounts, players, acsessor, fallback) {
 	);
 }
 
-async function cozRatings() {
-	try {
-		mongoose.Promise = global.Promise;
-		await mongoose.connect(`mongodb://localhost:15726/secret-hitler-app`);
-		await Game.find({}, { chats: 0 })
-			.cursor()
-			.eachAsync(async game => {
-				// Ignore casual games
-				if (game.casualGame) {
-					return;
-				}
-				// Get the players
-				const winningPlayerNames = game.winningPlayers.map(player => player.userName);
-				const losingPlayerNames = game.losingPlayers.map(player => player.userName);
-				const playerNames = winningPlayerNames.concat(losingPlayerNames);
-				// Then look up account information
-				let accounts = await Account.find({ username: { $in: playerNames } }, { eloOverall: 1, eloSeason: 1, username: 1 });
-				// Construct some basic statistics for each team
-				const b = (game.winningTeam === 'liberal') ? 1 : -1;
-				const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, 1600) + b * winAdjust[game.playerCount];
-				const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, 1600) - b * winAdjust[game.playerCount];
-				const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, 1600) + b * winAdjust[game.playerCount];
-				const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, 1600) - b * winAdjust[game.playerCount];
-				// Elo Formula
-				const k = 64;
-				const p = 1 / (1 + Math.pow(10, (averageRatingWinners - averageRatingLosers) / 400));
-				const pSeason = 1 / (1 + Math.pow(10, (averageRatingWinnersSeason - averageRatingLosersSeason) / 400));
-				// Calculate ratings deltas
-				const winningPlayerAdjustment = k * p / winningPlayerNames.length;
-				const losingPlayerAdjustment = -k * p / losingPlayerNames.length;
-				const winningPlayerAdjustmentSeason = k * pSeason / winningPlayerNames.length;
-				const losingPlayerAdjustmentSeason = -k * pSeason / losingPlayerNames.length;
-				// Apply the rating changes
-				for (let account of accounts) {
-					let eloOverall;
-					let eloSeason;
+async function rate(game) {
+	// Get the players
+	const winningPlayerNames = game.winningPlayers.map(player => player.userName);
+	const losingPlayerNames = game.losingPlayers.map(player => player.userName);
+	const playerNames = winningPlayerNames.concat(losingPlayerNames);
+	// Then look up account information
+	let accounts = await Account.find({ username: { $in: playerNames } }, { eloOverall: 1, eloSeason: 1, username: 1 });
+	// Construct some basic statistics for each team
+	const b = game.winningTeam === 'liberal' ? 1 : -1;
+	const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, 1600) + b * winAdjust[game.playerCount];
+	const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, 1600) - b * winAdjust[game.playerCount];
+	const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, 1600) + b * winAdjust[game.playerCount];
+	const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, 1600) - b * winAdjust[game.playerCount];
+	// Elo Formula
+	const k = 64;
+	const p = 1 / (1 + Math.pow(10, (averageRatingWinners - averageRatingLosers) / 400));
+	const pSeason = 1 / (1 + Math.pow(10, (averageRatingWinnersSeason - averageRatingLosersSeason) / 400));
+	// Calculate ratings deltas
+	const winningPlayerAdjustment = k * p / winningPlayerNames.length;
+	const losingPlayerAdjustment = -k * p / losingPlayerNames.length;
+	const winningPlayerAdjustmentSeason = k * pSeason / winningPlayerNames.length;
+	const losingPlayerAdjustmentSeason = -k * pSeason / losingPlayerNames.length;
+	// Apply the rating changes
+	for (let account of accounts) {
+		let eloOverall;
+		let eloSeason;
 
-					if (!account.eloOverall) {
-						eloOverall = 1600;
-						eloSeason = 1600;
-					} else {
-						eloOverall = account.eloOverall;
-						eloSeason = account.eloSeason;
-					}
+		if (!account.eloOverall) {
+			eloOverall = 1600;
+			eloSeason = 1600;
+		} else {
+			eloOverall = account.eloOverall;
+			eloSeason = account.eloSeason;
+		}
 
-					account.eloOverall = winningPlayerNames.includes(account.username) ? eloOverall + winningPlayerAdjustment : eloOverall + losingPlayerAdjustment;
-					if (game.season === CURRENTSEASONNUMBER) {
-						account.eloSeason = winningPlayerNames.includes(account.username) ? eloSeason + winningPlayerAdjustmentSeason : eloSeason + losingPlayerAdjustmentSeason;
-					}
+		account.eloOverall = winningPlayerNames.includes(account.username) ? eloOverall + winningPlayerAdjustment : eloOverall + losingPlayerAdjustment;
+		if (game.season === CURRENTSEASONNUMBER) {
+			account.eloSeason = winningPlayerNames.includes(account.username) ? eloSeason + winningPlayerAdjustmentSeason : eloSeason + losingPlayerAdjustmentSeason;
+		}
 
-					account.save();
-				}
-			});
-	} finally {
-		await mongoose.disconnect();
+		account.save();
 	}
 }
 
-cozRatings();
+AllGames(rate);

--- a/scripts/rating/nthRatings.js
+++ b/scripts/rating/nthRatings.js
@@ -29,6 +29,10 @@ async function cozRatings() {
 		await Game.find({}, { chats: 0 })
 			.cursor()
 			.eachAsync(async game => {
+				// Ignore casual games
+				if (game.casualGame) {
+					return;
+				}
 				// Get the players
 				const winningPlayerNames = game.winningPlayers.map(player => player.userName);
 				const losingPlayerNames = game.losingPlayers.map(player => player.userName);
@@ -50,7 +54,7 @@ async function cozRatings() {
 				const losingPlayerAdjustment = -k * p / losingPlayerNames.length;
 				const winningPlayerAdjustmentSeason = k * pSeason / winningPlayerNames.length;
 				const losingPlayerAdjustmentSeason = -k * pSeason / losingPlayerNames.length;
-				// Apply the rating chaanges
+				// Apply the rating changes
 				for (let account of accounts) {
 					let eloOverall;
 					let eloSeason;

--- a/scripts/rating/nthRatings.js
+++ b/scripts/rating/nthRatings.js
@@ -1,24 +1,30 @@
 const Summary = require('../../models/game-summary');
 const Account = require('../../models/account');
 const buildEnhancedGameSummary = require('../../models/game-summary/buildEnhancedGameSummary');
+const { CURRENTSEASONNUMBER } = require('../../src/frontend-scripts/constants');
 const mongoose = require('mongoose');
 
-// Players will be considered more influential when:
-// + Voting with the majority (+1pt per majority vote)
-// + Spending more time in government (+4pt per government)
-// + Using the special powers (+7pt for special power use)
-
-liberalRank = 1600;
-fascistRank = 1600;
-liberalSeasonRank = 1600;
-fascistSeasonRank = 1600;
+const winAdjust = {
+	5: -19.253,
+	6: 20.637,
+	7: -17.282,
+	8: 45.418,
+	9: -70.679,
+	10: -31.539
+};
 
 ja = async votes => votes.toArray().filter(b => b).length;
 nein = async votes => votes.toArray().filter(b => !b).length;
 passed = async votes => await ja(votes) > await nein(votes);
 
 softmax = arr => arr.map((value, index) => Math.exp(value) / arr.map(Math.exp).reduce((a, b) => a + b));
+avg = arr => arr.reduce( ( p, c ) => p + c, 0 ) / arr.length;
 
+// This function approximates the degree to wich each player may have influenced the end game result.
+// Players will be considered more influential when:
+// + Casting votes that may have changed the outcome of an election.
+// + Elected to governments.
+// + Using the presidential powers.
 async function influence(game) {
 	let weighting = new Array(game.playerSize).fill(0.0);
 	let red = 0;
@@ -30,6 +36,12 @@ async function influence(game) {
 					// voting with the majority on a close vote
 					weighting[v]++;
 				}
+			}
+		}
+		if (Math.abs(await ja(turn.votes) - await nein(turn.votes)) === 0) {
+			for (let v of turn.votes) {
+				// even number of fascist and liberal votes: everyone gets a point
+				weighting[v]++;
 			}
 		}
 		if (await p) {
@@ -46,8 +58,8 @@ async function influence(game) {
 		}
 	}
 	return softmax(weighting)
-		.map(v => (v + 5/game.playerSize)/6)
-		.map(v => game.playerSize * v);
+		.map(v => (v + 5/game.playerSize)/6) // Dampen so as to only account for 16% of ELO
+		.map(v => game.playerSize * v); // Normalise
 }
 
 async function rate(summary) {
@@ -68,8 +80,42 @@ async function rate(summary) {
 		weightedPlayerRank[i] = playerInfluence[i] * account.eloOverall;
 		weightedPlayerSeasonRank[i] = playerInfluence[i] * account.eloSeason;
 	}
-	console.log(playerInfluence);
-	console.log(weightedPlayerRank);
+	const averageRatingWinners = avg(weightedPlayerRank.filter((_, i) => game.isWinner(i)._value)) + b * winAdjust[game.playerSize];
+	const averageRatingLosers = avg(weightedPlayerRank.filter((_, i) => !game.isWinner(i)._value)) - b * winAdjust[game.playerSize];
+	const averageRatingWinnersSeason = avg(weightedPlayerSeasonRank.filter((_, i) => game.isWinner(i)._value)) + b * winAdjust[game.playerSize];
+	const averageRatingLosersSeason = avg(weightedPlayerSeasonRank.filter((_, i) => !game.isWinner(i)._value)) - b * winAdjust[game.playerSize];
+
+	// Elo Formula
+	const k = 64;
+	const winFactor = k / winningPlayerNames.length;
+	const loseFactor = -k / losingPlayerNames.length;
+	const p = 1 / (1 + Math.pow(10, (averageRatingWinners - averageRatingLosers) / 400));
+	const pSeason = 1 / (1 + Math.pow(10, (averageRatingWinnersSeason - averageRatingLosersSeason) / 400));
+	// Apply the rating changes
+	for (let account of await Account.find({ username: { $in: playerNames } }, { eloOverall: 1, eloSeason: 1, username: 1 })) {
+		let eloOverall, eloSeason;
+		if (!account.eloOverall) {
+			eloOverall = 1600;
+			eloSeason = 1600;
+		} else {
+			eloOverall = account.eloOverall;
+			eloSeason = account.eloSeason;
+		}
+		const influence = playerInfluence[playerNames.indexOf(account.username)];
+		const win = winningPlayerNames.includes(account.username);
+		if (win) {
+			change = p * winFactor * influence;
+			changeSeason = pSeason * winFactor * influence;
+		} else {
+			change = p * loseFactor * influence;
+			changeSeason = pSeason * loseFactor * influence;
+		}
+		account.eloOverall = eloOverall + change;
+		if (game.season === CURRENTSEASONNUMBER) {
+			account.eloSeason = eloSeason + changeSeason;
+		}
+		await account.save();
+	}
 }
 
 async function allSummaries(rate) {

--- a/scripts/rating/nthRatings.js
+++ b/scripts/rating/nthRatings.js
@@ -1,0 +1,79 @@
+const Game = require('../../models/game'); // temp
+const Account = require('../../models/account'); // temp
+const mongoose = require('mongoose');
+const { CURRENTSEASONNUMBER } = require('../../src/frontend-scripts/constants');
+
+const winAdjust = {
+	5: -19.253,
+	6: 20.637,
+	7: -17.282,
+	8: 45.418,
+	9: -70.679,
+	10: -31.539
+};
+
+function avg(accounts, players, acsessor, fallback) {
+	return (
+		players.reduce(
+			(prev, curr) =>
+				acsessor(accounts.find(account => account.username === curr)) ? acsessor(accounts.find(account => account.username === curr)) + prev : fallback,
+			0
+		) / players.length
+	);
+}
+
+async function cozRatings() {
+	try {
+		mongoose.Promise = global.Promise;
+		await mongoose.connect(`mongodb://localhost:15726/secret-hitler-app`);
+		await Game.find({}, { chats: 0 })
+			.cursor()
+			.eachAsync(async game => {
+				// Get the players
+				const winningPlayerNames = game.winningPlayers.map(player => player.userName);
+				const losingPlayerNames = game.losingPlayers.map(player => player.userName);
+				const playerNames = winningPlayerNames.concat(losingPlayerNames);
+				// Then look up account information
+				let accounts = await Account.find({ username: { $in: playerNames } }, { eloOverall: 1, eloSeason: 1, username: 1 });
+				// Construct some basic statistics for each team
+				const b = (game.winningTeam === 'liberal') ? 1 : -1;
+				const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, 1600) + b * winAdjust[game.playerCount];
+				const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, 1600) - b * winAdjust[game.playerCount];
+				const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, 1600) + b * winAdjust[game.playerCount];
+				const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, 1600) - b * winAdjust[game.playerCount];
+				// Elo Formula
+				const k = 64;
+				const p = 1 / (1 + Math.pow(10, (averageRatingWinners - averageRatingLosers) / 400));
+				const pSeason = 1 / (1 + Math.pow(10, (averageRatingWinnersSeason - averageRatingLosersSeason) / 400));
+				// Calculate ratings deltas
+				const winningPlayerAdjustment = k * p / winningPlayerNames.length;
+				const losingPlayerAdjustment = -k * p / losingPlayerNames.length;
+				const winningPlayerAdjustmentSeason = k * pSeason / winningPlayerNames.length;
+				const losingPlayerAdjustmentSeason = -k * pSeason / losingPlayerNames.length;
+				// Apply the rating chaanges
+				for (let account of accounts) {
+					let eloOverall;
+					let eloSeason;
+
+					if (!account.eloOverall) {
+						eloOverall = 1600;
+						eloSeason = 1600;
+					} else {
+						eloOverall = account.eloOverall;
+						eloSeason = account.eloSeason;
+					}
+
+					account.eloOverall = winningPlayerNames.includes(account.username) ? eloOverall + winningPlayerAdjustment : eloOverall + losingPlayerAdjustment;
+					if (game.season === CURRENTSEASONNUMBER) {
+						account.eloSeason = winningPlayerNames.includes(account.username) ? eloSeason + winningPlayerAdjustmentSeason : eloSeason + losingPlayerAdjustmentSeason;
+					}
+
+					account.save();
+				}
+			});
+	} finally {
+		await mongoose.disconnect();
+	}
+}
+
+cozRatings();

--- a/scripts/rating/nthRatings.js
+++ b/scripts/rating/nthRatings.js
@@ -22,6 +22,7 @@ function avg(accounts, players, acsessor, fallback) {
 }
 
 async function rate(game) {
+	console.log(game);
 	// Get the players
 	const winningPlayerNames = game.winningPlayers.map(player => player.userName);
 	const losingPlayerNames = game.losingPlayers.map(player => player.userName);
@@ -61,7 +62,7 @@ async function rate(game) {
 			account.eloSeason = winningPlayerNames.includes(account.username) ? eloSeason + winningPlayerAdjustmentSeason : eloSeason + losingPlayerAdjustmentSeason;
 		}
 
-		account.save();
+		await account.save();
 	}
 }
 

--- a/scripts/rating/printRatings.js
+++ b/scripts/rating/printRatings.js
@@ -1,0 +1,20 @@
+const Account = require('../../models/account'); // temp
+const mongoose = require('mongoose');
+
+async function clearRatings() {
+	try {
+		mongoose.Promise = global.Promise;
+		await mongoose.connect(`mongodb://localhost:15726/secret-hitler-app`);
+		await Account
+			.find()
+			.sort('-eloSeason')
+			.cursor()
+			.eachAsync(account => {
+				console.log(`${account.username.padStart(20)}: ${account.eloSeason.toFixed(1)} (${account.eloOverall.toFixed(1)})`);
+			});
+	} finally {
+		await mongoose.disconnect();
+	}
+}
+
+clearRatings();

--- a/scripts/rating/readme.md
+++ b/scripts/rating/readme.md
@@ -1,0 +1,7 @@
++ `clearRatings.js` resets all players back to 1600. (done)
++ `pringRatings.js` prints the elo of all accounts in a nicely formatted list. (done)
++ `cozRaitings.js` is a re-implementation of the current ELO system. (done)
++ `hexRatings.js` is a the above re-implementation with hexi's changes added on top. (done)
++ `nthRaitings.js` is nth's crazy ELO system. (sill very much WIP)
+
+**All of these will modify the active database/overwite current vadlues.**

--- a/scripts/rating/readme.md
+++ b/scripts/rating/readme.md
@@ -1,7 +1,7 @@
 + `clearRatings.js` resets all players back to 1600. (done)
 + `pringRatings.js` prints the elo of all accounts in a nicely formatted list. (done)
 + `cozRaitings.js` is a re-implementation of the current ELO system. (done)
-+ `hexRatings.js` is a the above re-implementation with hexi's changes added on top. (done)
-+ `nthRaitings.js` is nth's crazy ELO system. (sill very much WIP)
++ `hexRatings.js` is the above re-implementation with hexi's changes added on top. (done)
++ `nthRaitings.js` is the above re-implementation with a player importance metric added. (done)
 
 **All of these will modify the active database/overwite current vadlues.**


### PR DESCRIPTION
+ `clearRatings.js` resets all players back to 1600. (done)
+ `pringRatings.js` prints the elo of all accounts in a nicely formatted list. (done)
+ `cozRaitings.js` is a re-implementation of the current ELO system. (done)
+ `hexRatings.js` is a the above re-implementation with hexi's changes added on top. (done)
+ `nthRaitings.js` is nth's crazy ELO system. (sill very much WIP)

**All of these will modify the active database/overwite current vadlues.**