### PR TITLE
Elo Tweaks

### DIFF
--- a/routes/socket/game/end-game.js
+++ b/routes/socket/game/end-game.js
@@ -148,41 +148,6 @@ module.exports.completeGame = (game, winningTeamName) => {
 				const isTournamentFinalGame = game.general.isTourny && game.general.tournyInfo.round === 2;
 
 				const eloAdjustments = rateEloGame(game, results, winningPlayerNames);
-				const adjustmentChat = {
-					gameChat: true,
-					timestamp: new Date(),
-					chat: [
-						{
-							text: winningTeamName === 'fascist' ? 'Fascists' : 'Liberals',
-							type: winningTeamName === 'fascist' ? 'fascist' : 'liberal'
-						},
-						{
-							text: ' gain '
-						},
-						{
-							text: eloAdjustments.winningPlayerAdjustment.toFixed(0),
-							type: 'player'
-						},
-						{
-							text: ' elo. '
-						},
-						{
-							text: winningTeamName === 'fascist' ? 'Liberals' : 'Fascists',
-							type: winningTeamName === 'fascist' ? 'liberal' : 'fascist'
-						},
-						{
-							text: ' lose '
-						},
-						{
-							text: -1 * eloAdjustments.losingPlayerAdjustment.toFixed(0),
-							type: 'player'
-						},
-						{
-							text: ' elo.'
-						}
-					]
-				};
-
 				seatedPlayers.forEach(player => {
 					rank = eloAdjustments[player.username];
 					player.gameChats.push({
@@ -195,7 +160,10 @@ module.exports.completeGame = (game, winningTeamName) => {
 							{
 								text: Math.abs((rank.change).toFixed(1)),
 								type: 'player'
-							}
+							},
+							{
+								text: ` points.`
+							},
 						]
 					});
 					player.gameChats.push({
@@ -208,6 +176,9 @@ module.exports.completeGame = (game, winningTeamName) => {
 							{
 								text: Math.abs((rank.changeSeason).toFixed(1)),
 								type: 'player'
+							},
+							{
+								text: ` points.`
 							}
 						]
 					});

--- a/routes/socket/game/end-game.js
+++ b/routes/socket/game/end-game.js
@@ -149,7 +149,7 @@ module.exports.completeGame = (game, winningTeamName) => {
 
 				const eloAdjustments = rateEloGame(game, results, winningPlayerNames);
 				seatedPlayers.forEach(player => {
-					rank = eloAdjustments[player.username];
+					const rank = eloAdjustments[player.userName];
 					player.gameChats.push({
 						gameChat: true,
 						timestamp: new Date(),

--- a/routes/socket/game/end-game.js
+++ b/routes/socket/game/end-game.js
@@ -184,7 +184,33 @@ module.exports.completeGame = (game, winningTeamName) => {
 				};
 
 				seatedPlayers.forEach(player => {
-					player.gameChats.push(adjustmentChat);
+					rank = eloAdjustments[player.username];
+					player.gameChats.push({
+						gameChat: true,
+						timestamp: new Date(),
+						chat: [
+							{
+								text: `Your overall rank has ${rank.change > 0 ? 'increased' : 'decreased'} by `
+							},
+							{
+								text: Math.abs((rank.change).toFixed(1)),
+								type: 'player'
+							}
+						]
+					});
+					player.gameChats.push({
+						gameChat: true,
+						timestamp: new Date(),
+						chat: [
+							{
+								text: `Your seasonal rank has ${rank.changeSeason > 0 ? 'increased' : 'decreased'} by`
+							},
+							{
+								text: Math.abs((rank.changeSeason).toFixed(1)),
+								type: 'player'
+							}
+						]
+					});
 				});
 
 				game.private.unSeatedGameChats.push(adjustmentChat);

--- a/routes/socket/game/end-game.js
+++ b/routes/socket/game/end-game.js
@@ -184,8 +184,6 @@ module.exports.completeGame = (game, winningTeamName) => {
 					});
 				});
 
-				game.private.unSeatedGameChats.push(adjustmentChat);
-
 				sendInProgressGameUpdate(game);
 
 				results.forEach(player => {

--- a/routes/socket/game/end-game.js
+++ b/routes/socket/game/end-game.js
@@ -171,7 +171,7 @@ module.exports.completeGame = (game, winningTeamName) => {
 						timestamp: new Date(),
 						chat: [
 							{
-								text: `Your seasonal rank has ${rank.changeSeason > 0 ? 'increased' : 'decreased'} by`
+								text: `Your seasonal rank has ${rank.changeSeason > 0 ? 'increased' : 'decreased'} by `
 							},
 							{
 								text: Math.abs(rank.changeSeason.toFixed(1)),

--- a/routes/socket/game/end-game.js
+++ b/routes/socket/game/end-game.js
@@ -158,12 +158,12 @@ module.exports.completeGame = (game, winningTeamName) => {
 								text: `Your overall rank has ${rank.change > 0 ? 'increased' : 'decreased'} by `
 							},
 							{
-								text: Math.abs((rank.change).toFixed(1)),
+								text: Math.abs(rank.change.toFixed(1)),
 								type: 'player'
 							},
 							{
 								text: ` points.`
-							},
+							}
 						]
 					});
 					player.gameChats.push({
@@ -174,7 +174,7 @@ module.exports.completeGame = (game, winningTeamName) => {
 								text: `Your seasonal rank has ${rank.changeSeason > 0 ? 'increased' : 'decreased'} by`
 							},
 							{
-								text: Math.abs((rank.changeSeason).toFixed(1)),
+								text: Math.abs(rank.changeSeason.toFixed(1)),
 								type: 'player'
 							},
 							{

--- a/routes/socket/util.js
+++ b/routes/socket/util.js
@@ -87,7 +87,7 @@ function avg(accounts, players, accessor, fallback) {
 	return (
 		players.reduce(
 			(prev, curr) =>
-				accessor(accounts.find(account => account.username === curr)) ? acsessor(accounts.find(account => account.username === curr)) + prev : fallback,
+				accessor(accounts.find(account => account.username === curr)) ? accessor(accounts.find(account => account.username === curr)) + prev : fallback,
 			0
 		) / players.length
 	);
@@ -106,13 +106,16 @@ module.exports.rateEloGame = (game, accounts, winningPlayerNames) => {
 	};
 	const k = 64;
 	// Players
-	const losingPlayerNames = game.private.seatedPlayers.filter(player => !winningPlayerNames.includes(player.userName)).map(player => player.userName);
+	const losingPlayerNames = game.private.seatedPlayers
+		.filter(player => !winningPlayerNames.includes(player.userName))
+		.map(player => player.userName);
 	// Construct some basic statistics for each team
-	const b = game.winningTeam === 'liberal' ? 1 : -1;
-	const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, defaultELO) + b * winAdjust[game.playerCount];
-	const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, defaultELO) - b * winAdjust[game.playerCount];
-	const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, defaultELO) + b * winAdjust[game.playerCount];
-	const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, defaultELO) - b * winAdjust[game.playerCount];
+	const b = game.gameState.isCompleted === 'liberal' ? 1 : -1;
+	const size = game.private.seatedPlayers.length;
+	const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, defaultELO) + b * winAdjust[size];
+	const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, defaultELO) - b * winAdjust[size];
+	const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, defaultELO) + b * winAdjust[size];
+	const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, defaultELO) - b * winAdjust[size];
 	// Elo Formula
 	const winFactor = k / winningPlayerNames.length;
 	const loseFactor = -k / losingPlayerNames.length;

--- a/routes/socket/util.js
+++ b/routes/socket/util.js
@@ -96,7 +96,7 @@ function avg(accounts, players, accessor, fallback) {
 module.exports.rateEloGame = (game, accounts, winningPlayerNames) => {
 	// ELO constants
 	const defaultELO = 1600;
-	const winAdjust = {
+	const libAdjust = {
 		5: -19.253,
 		6: 20.637,
 		7: -17.282,
@@ -110,12 +110,12 @@ module.exports.rateEloGame = (game, accounts, winningPlayerNames) => {
 		.filter(player => !winningPlayerNames.includes(player.userName))
 		.map(player => player.userName);
 	// Construct some basic statistics for each team
-	const b = game.gameState.isCompleted === 'liberal' ? 1 : -1;
+	const b = game.gameState.isCompleted === 'liberal' ? 1 : 0;
 	const size = game.private.seatedPlayers.length;
-	const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, defaultELO) + b * winAdjust[size];
-	const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, defaultELO) - b * winAdjust[size];
-	const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, defaultELO) + b * winAdjust[size];
-	const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, defaultELO) - b * winAdjust[size];
+	const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, defaultELO) + b * libAdjust[size];
+	const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, defaultELO) + b * libAdjust[size];
+	const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, defaultELO) - b * libAdjust[size];
+	const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, defaultELO) - b * libAdjust[size];
 	// Elo Formula
 	const winFactor = k / winningPlayerNames.length;
 	const loseFactor = -k / losingPlayerNames.length;

--- a/routes/socket/util.js
+++ b/routes/socket/util.js
@@ -83,9 +83,20 @@ module.exports.sendInProgressGameUpdate = game => {
 
 module.exports.secureGame = secureGame;
 
+function avg(accounts, players, acsessor, fallback) {
+	return (
+		players.reduce(
+			(prev, curr) =>
+				acsessor(accounts.find(account => account.username === curr)) ? acsessor(accounts.find(account => account.username === curr)) + prev : fallback,
+			0
+		) / players.length
+	);
+}
+
 module.exports.rateEloGame = (game, accounts, winningPlayerNames) => {
-	const losingPlayerNames = game.private.seatedPlayers.filter(player => !winningPlayerNames.includes(player.userName)).map(player => player.userName);
-	const libWinAdjust = {
+	// ELO constants
+	const defaultELO = 1600;
+	const winAdjust = {
 		5: -19.253,
 		6: 20.637,
 		7: -17.282,
@@ -93,68 +104,31 @@ module.exports.rateEloGame = (game, accounts, winningPlayerNames) => {
 		9: -70.679,
 		10: -31.539
 	};
-	let averageRatingWinners =
-		winningPlayerNames.reduce(
-			(prev, curr) =>
-				accounts.find(account => account.username === curr).eloOverall ? accounts.find(account => account.username === curr).eloOverall + prev : 1600,
-			0
-		) / winningPlayerNames.length;
-	let averageRatingWinnersSeason =
-		winningPlayerNames.reduce(
-			(prev, curr) =>
-				accounts.find(account => account.username === curr).eloOverall ? accounts.find(account => account.username === curr).eloOverall + prev : 1600,
-			0
-		) / winningPlayerNames.length;
-	let averageRatingLosers =
-		losingPlayerNames.reduce(
-			(prev, curr) =>
-				accounts.find(account => account.username === curr).eloSeason ? accounts.find(account => account.username === curr).eloSeason + prev : 1600,
-			0
-		) / losingPlayerNames.length;
-	let averageRatingLosersSeason =
-		losingPlayerNames.reduce(
-			(prev, curr) =>
-				accounts.find(account => account.username === curr).eloSeason ? accounts.find(account => account.username === curr).eloSeason + prev : 1600,
-			0
-		) / losingPlayerNames.length;
-
-	if (game.gameState.isCompleted === 'liberal') {
-		averageRatingWinners += libWinAdjust[game.private.seatedPlayers.length];
-		averageRatingWinnersSeason += libWinAdjust[game.private.seatedPlayers.length];
-	} else {
-		averageRatingLosers += libWinAdjust[game.private.seatedPlayers.length];
-		averageRatingLosersSeason += libWinAdjust[game.private.seatedPlayers.length];
-	}
-
 	const k = 64;
+	// Players
+	const losingPlayerNames = game.private.seatedPlayers.filter(player => !winningPlayerNames.includes(player.userName)).map(player => player.userName);
+	// Construct some basic statistics for each team
+	const b = game.winningTeam === 'liberal' ? 1 : -1;
+	const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, defaultELO) + b * winAdjust[game.playerCount];
+	const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, defaultELO) - b * winAdjust[game.playerCount];
+	const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, defaultELO) + b * winAdjust[game.playerCount];
+	const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, defaultELO) - b * winAdjust[game.playerCount];
+	// Elo Formula
+	const winFactor = k / winningPlayerNames.length;
+	const loseFactor = -k / losingPlayerNames.length;
 	const p = 1 / (1 + Math.pow(10, (averageRatingWinners - averageRatingLosers) / 400));
 	const pSeason = 1 / (1 + Math.pow(10, (averageRatingWinnersSeason - averageRatingLosersSeason) / 400));
-
-	const winningPlayerAdjustment = k * p / winningPlayerNames.length;
-	const losingPlayerAdjustment = -k * p / losingPlayerNames.length;
-	const winningPlayerAdjustmentSeason = k * pSeason / winningPlayerNames.length;
-	const losingPlayerAdjustmentSeason = -k * pSeason / losingPlayerNames.length;
-
+	let ratingUpdates = {};
 	accounts.forEach(account => {
-		let eloOverall;
-		let eloSeason;
-
-		if (!account.eloOverall) {
-			eloOverall = 1600;
-			eloSeason = 1600;
-		} else {
-			eloOverall = account.eloOverall;
-			eloSeason = account.eloSeason;
-		}
-
-		account.eloOverall = winningPlayerNames.includes(account.username) ? eloOverall + winningPlayerAdjustment : eloOverall + losingPlayerAdjustment;
-		account.eloSeason = winningPlayerNames.includes(account.username) ? eloSeason + winningPlayerAdjustmentSeason : eloSeason + losingPlayerAdjustmentSeason;
-
+		const eloOverall = account.eloOverall ? account.eloOverall : defaultELO;
+		const eloSeason = account.eloSeason ? account.eloSeason : defaultELO;
+		const factor = winningPlayerNames.includes(account.username) ? winFactor : loseFactor;
+		const change = p * factor;
+		const changeSeason = pSeason * factor;
+		account.eloOverall = eloOverall + change;
+		account.eloSeason = eloSeason + changeSeason;
 		account.save();
+		ratingUpdates[account.username] = { change, changeSeason };
 	});
-
-	return {
-		winningPlayerAdjustment,
-		losingPlayerAdjustment
-	};
+	return ratingUpdates;
 };

--- a/routes/socket/util.js
+++ b/routes/socket/util.js
@@ -83,11 +83,11 @@ module.exports.sendInProgressGameUpdate = game => {
 
 module.exports.secureGame = secureGame;
 
-function avg(accounts, players, acsessor, fallback) {
+function avg(accounts, players, accessor, fallback) {
 	return (
 		players.reduce(
 			(prev, curr) =>
-				acsessor(accounts.find(account => account.username === curr)) ? acsessor(accounts.find(account => account.username === curr)) + prev : fallback,
+				accessor(accounts.find(account => account.username === curr)) ? acsessor(accounts.find(account => account.username === curr)) + prev : fallback,
 			0
 		) / players.length
 	);

--- a/scripts/rating/cozRatings.js
+++ b/scripts/rating/cozRatings.js
@@ -2,7 +2,7 @@ const AllGames = require('./allGames');
 const Account = require('../../models/account');
 const { CURRENTSEASONNUMBER } = require('../../src/frontend-scripts/constants');
 
-const winAdjust = {
+const libAdjust = {
 	5: -19.253,
 	6: 20.637,
 	7: -17.282,
@@ -29,11 +29,11 @@ async function rate(game) {
 	// Then look up account information
 	let accounts = await Account.find({ username: { $in: playerNames } }, { eloOverall: 1, eloSeason: 1, username: 1 });
 	// Construct some basic statistics for each team
-	const b = game.winningTeam === 'liberal' ? 1 : -1;
-	const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, 1600) + b * winAdjust[game.playerCount];
-	const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, 1600) - b * winAdjust[game.playerCount];
-	const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, 1600) + b * winAdjust[game.playerCount];
-	const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, 1600) - b * winAdjust[game.playerCount];
+	const b = game.winningTeam === 'liberal' ? 1 : 0;
+	const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, 1600) + b * libAdjust[game.playerCount];
+	const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, 1600) - b * libAdjust[game.playerCount];
+	const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, 1600) + b * libAdjust[game.playerCount];
+	const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, 1600) - b * libAdjust[game.playerCount];
 	// Elo Formula
 	const k = 64;
 	const winFactor = k / winningPlayerNames.length;

--- a/scripts/rating/hexRatings.js
+++ b/scripts/rating/hexRatings.js
@@ -2,7 +2,7 @@ const AllGames = require('./allGames');
 const Account = require('../../models/account');
 const { CURRENTSEASONNUMBER } = require('../../src/frontend-scripts/constants');
 
-const winAdjust = {
+const libAdjust = {
 	5: -19.253,
 	6: 20.637,
 	7: -17.282,
@@ -29,11 +29,11 @@ async function rate(game) {
 	// Then look up account information
 	let accounts = await Account.find({ username: { $in: playerNames } }, { eloOverall: 1, eloSeason: 1, username: 1 });
 	// Construct some basic statistics for each team
-	const b = game.winningTeam === 'liberal' ? 1 : -1;
-	const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, 1600) + b * winAdjust[game.playerCount];
-	const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, 1600) - b * winAdjust[game.playerCount];
-	const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, 1600) + b * winAdjust[game.playerCount];
-	const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, 1600) - b * winAdjust[game.playerCount];
+	const b = game.winningTeam === 'liberal' ? 1 : 0;
+	const averageRatingWinners = avg(accounts, winningPlayerNames, a => a.eloOverall, 1600) + b * libAdjust[game.playerCount];
+	const averageRatingLosers = avg(accounts, losingPlayerNames, a => a.eloOverall, 1600) - b * libAdjust[game.playerCount];
+	const averageRatingWinnersSeason = avg(accounts, winningPlayerNames, a => a.eloSeason, 1600) + b * libAdjust[game.playerCount];
+	const averageRatingLosersSeason = avg(accounts, losingPlayerNames, a => a.eloSeason, 1600) - b * libAdjust[game.playerCount];
 	// Hexi's Elo constants
 	const k = 64;
 	const winFactor = k / winningPlayerNames.length;

--- a/scripts/rating/nthRatings.js
+++ b/scripts/rating/nthRatings.js
@@ -4,7 +4,7 @@ const buildEnhancedGameSummary = require('../../models/game-summary/buildEnhance
 const { CURRENTSEASONNUMBER } = require('../../src/frontend-scripts/constants');
 const mongoose = require('mongoose');
 
-const winAdjust = {
+const libAdjust = {
 	5: -19.253,
 	6: 20.637,
 	7: -17.282,
@@ -78,7 +78,7 @@ async function rate(summary) {
 	const playerNames = game.players.map(player => player.username).toArray();
 	const playerInfluence = await influence(game);
 	// Construct some basic statistics for each team
-	const b = game.winningTeam === 'liberal' ? 1 : -1;
+	const b = game.winningTeam === 'liberal' ? 1 : 0;
 	let weightedPlayerRank = new Array(game.playerSize);
 	let weightedPlayerSeasonRank = new Array(game.playerSize);
 	for (let i in playerNames) {
@@ -86,10 +86,10 @@ async function rate(summary) {
 		weightedPlayerRank[i] = playerInfluence[i] * account.eloOverall;
 		weightedPlayerSeasonRank[i] = playerInfluence[i] * account.eloSeason;
 	}
-	const averageRatingWinners = avg(weightedPlayerRank.filter((_, i) => game.isWinner(i)._value)) + b * winAdjust[game.playerSize];
-	const averageRatingLosers = avg(weightedPlayerRank.filter((_, i) => !game.isWinner(i)._value)) - b * winAdjust[game.playerSize];
-	const averageRatingWinnersSeason = avg(weightedPlayerSeasonRank.filter((_, i) => game.isWinner(i)._value)) + b * winAdjust[game.playerSize];
-	const averageRatingLosersSeason = avg(weightedPlayerSeasonRank.filter((_, i) => !game.isWinner(i)._value)) - b * winAdjust[game.playerSize];
+	const averageRatingWinners = avg(weightedPlayerRank.filter((_, i) => game.isWinner(i)._value)) + b * libAdjust[game.playerSize];
+	const averageRatingLosers = avg(weightedPlayerRank.filter((_, i) => !game.isWinner(i)._value)) - b * libAdjust[game.playerSize];
+	const averageRatingWinnersSeason = avg(weightedPlayerSeasonRank.filter((_, i) => game.isWinner(i)._value)) + b * libAdjust[game.playerSize];
+	const averageRatingLosersSeason = avg(weightedPlayerSeasonRank.filter((_, i) => !game.isWinner(i)._value)) - b * libAdjust[game.playerSize];
 
 	// Elo Formula
 	const k = 64;


### PR DESCRIPTION
I think its likely will have to do some tweaking to ELO after it goes live, to find something that feels right. It may involve individualized player deltas or it may not, but either way, this PR should simplify future ELO modifications. This PR does two things.
1. cleans up the `rateEloGame` code
2. makes rank change messages unique to each user, and private.