### PR TITLE
🐛 - Fixed bad conditions for already existing username

### DIFF
--- a/docs/rateGame.js
+++ b/docs/rateGame.js
@@ -63,10 +63,10 @@ Game.findOne({}, { chats: 0 })
 				const p = 1 / (1 + Math.pow(10, (averageRatingWinners - averageRatingLosers) / 400));
 				const pSeason = 1 / (1 + Math.pow(10, (averageRatingWinnersSeason - averageRatingLosersSeason) / 400));
 
-				const winningPlayerAdjustment = k * p / winningPlayerNames.length;
-				const losingPlayerAdjustment = -k * p / losingPlayerNames.length;
-				const winningPlayerAdjustmentSeason = k * pSeason / winningPlayerNames.length;
-				const losingPlayerAdjustmentSeason = -k * pSeason / losingPlayerNames.length;
+				const winningPlayerAdjustment = (k * p) / winningPlayerNames.length;
+				const losingPlayerAdjustment = (-k * p) / losingPlayerNames.length;
+				const winningPlayerAdjustmentSeason = (k * pSeason) / winningPlayerNames.length;
+				const losingPlayerAdjustmentSeason = (-k * pSeason) / losingPlayerNames.length;
 
 				accounts.forEach(account => {
 					account.eloOverall = winningPlayerNames.includes(account.username)

--- a/routes/accounts.js
+++ b/routes/accounts.js
@@ -163,12 +163,11 @@ module.exports = () => {
 					message: 'Sorry, your username contains a naughty word or part of a naughty word.'
 				});
 			} else {
-				Account.findOne({ username: username.toLowerCase() }, (err, account) => {
+				Account.findOne({ username }, (err, account) => {
 					if (err) {
 						return next(err);
 					}
-
-					if (account && account.username === username.toLowerCase()) {
+					if (account && account.username === username) {
 						res.status(401).json({ message: 'Sorry, that account already exists.' });
 					} else {
 						BannedIP.find({ ip: signupIP }, (err, ips) => {

--- a/scripts/dump-curelo.js
+++ b/scripts/dump-curelo.js
@@ -49,7 +49,10 @@ db.once('open', function() {
 	getMoreData(0);
 });
 
-mongoose.connect('mongodb://localhost:32001/secret-hitler-app', (err, db) => {
-	if (err) console.error(err);
-	else console.log('Connect ok!');
-});
+mongoose.connect(
+	'mongodb://localhost:32001/secret-hitler-app',
+	(err, db) => {
+		if (err) console.error(err);
+		else console.log('Connect ok!');
+	}
+);


### PR DESCRIPTION
When trying to sign up with an username that already exists, and happens to have capitalized letters, the server would returns 500.
That happens because the functions looks for the username in lowercase in Mongo.

Example : Username = EIS
Looks for eis in mongo -> Doesnt exist
Tries to insert username EIS in database, Mongo reject it because username EIS already exists.
Fire 500 error