### PR TITLE
Remove non-existing call to hi()' in Generalchat.jsx

### DIFF
--- a/src/frontend-scripts/components/section-right/Generalchat.jsx
+++ b/src/frontend-scripts/components/section-right/Generalchat.jsx
@@ -144,7 +144,6 @@ export default class Generalchat extends React.Component {
 		let timestamp;
 		const { userInfo, userList, generalChats } = this.props;
 		const time = new Date().getTime();
-		hi();
 
 		/**
 		 * @param {array} tournyWins - array of tournywins in epoch ms numbers (date.getTime())


### PR DESCRIPTION
I just pulled the code, tried running a dev server and noticed this call in the latest commit which breaks the rendering because it doesn't exist.