### PR TITLE
Prevent default event execution in noteDrop

### DIFF
--- a/src/frontend-scripts/components/Gamenotes.jsx
+++ b/src/frontend-scripts/components/Gamenotes.jsx
@@ -42,6 +42,7 @@ class Gamenotes extends React.Component {
 	resizeDragStart() {}
 
 	noteDrop(e) {
+		e.preventDefault();
 		if (!this.state.isResizing) {
 			const offset = e.dataTransfer.getData('text/plain').split(',');
 


### PR DESCRIPTION
This solves #193 (or probably rather just #425)

Due to the use of `e.dataTransfer` Firefox thinks this is data that can be loaded into the browser window, which is the default behaviour. We can easily fix this by prevent the default event from happening using `e.preventDefault()`. This simply fixes the notes window in Firefox where it currently can't be moved.

Tested in Firefox 62.0.3 (64-bit) on macOS 10.14.