### PR TITLE
Clean notes code

### DIFF
--- a/src/frontend-scripts/components/Gamenotes.jsx
+++ b/src/frontend-scripts/components/Gamenotes.jsx
@@ -4,63 +4,33 @@ import { toggleNotes } from '../actions/actions';
 import PropTypes from 'prop-types';
 
 const mapDispatchToProps = dispatch => ({
-		toggleNotes: notesStatus => dispatch(toggleNotes(notesStatus))
-	}),
-	dragOverFn = e => {
-		e.preventDefault();
-	};
+	dismissNotes: () => dispatch(toggleNotes(false))
+});
 
 class Gamenotes extends React.Component {
 	constructor() {
 		super();
 
-		this.clearNotes = this.clearNotes.bind(this);
 		this.noteDragStart = this.noteDragStart.bind(this);
-		this.dismissNotes = this.dismissNotes.bind(this);
-		this.noteDrop = this.noteDrop.bind(this);
-		this.resizeDragStart = this.resizeDragStart.bind(this);
+		this.noteDragOver = this.noteDragOver.bind(this);
+		this.noteDragDrop = this.noteDragDrop.bind(this);
 
 		this.state = {
 			top: 110,
 			left: 690,
 			width: 400,
-			height: 320,
-			isResizing: false
+			height: 320
 		};
 	}
 
-	clearNotes() {
-		this.props.changeNotesValue('');
-	}
-
-	dismissNotes() {
-		const { toggleNotes } = this.props;
-
-		toggleNotes(false);
-	}
-
-	resizeDragStart() {}
-
-	noteDrop(e) {
-		e.preventDefault();
-		if (!this.state.isResizing) {
-			const offset = e.dataTransfer.getData('coordinates/text').split(',');
-
-			this.setState({
-				top: e.clientY + parseInt(offset[1], 10),
-				left: e.clientX + parseInt(offset[0], 10)
-			});
-		}
-	}
-
 	componentDidMount() {
-		document.body.addEventListener('dragover', dragOverFn);
-		document.body.addEventListener('drop', this.noteDrop);
+		document.body.addEventListener('dragover', this.noteDragOver);
+		document.body.addEventListener('drop', this.noteDragDrop);
 	}
 
 	componentWillUnmount() {
-		document.body.removeEventListener('dragover', dragOverFn);
-		document.body.removeEventListener('drop', this.noteDrop);
+		document.body.removeEventListener('dragover', this.noteDragOver);
+		document.body.removeEventListener('drop', this.noteDragDrop);
 	}
 
 	noteDragStart(e) {
@@ -72,40 +42,56 @@ class Gamenotes extends React.Component {
 		);
 	}
 
+	noteDragOver(e) {
+		e.preventDefault();
+	}
+
+	noteDragDrop(e) {
+		e.preventDefault();
+		const offset = e.dataTransfer.getData('coordinates/text').split(',');
+
+		this.setState({
+			top: e.clientY + parseInt(offset[1], 10),
+			left: e.clientX + parseInt(offset[0], 10)
+		});
+	}
+
 	render() {
-		const notesChange = e => {
-			this.props.changeNotesValue(`${e.target.value}`);
-		};
+		const { changeNotesValue, dismissNotes, value } = this.props;
+		const { left: sectionLeft, top: sectionTop, height: sectionHeight, width: sectionWidth } = this.state;
 
 		return (
 			<section
 				draggable="true"
 				onDragStart={this.noteDragStart}
 				className="notes-container"
-				style={{ top: `${this.state.top}px`, left: `${this.state.left}px`, height: `${this.state.height}px`, width: `${this.state.width}px` }}
+				style={{ top: `${sectionTop}px`, left: `${sectionLeft}px`, height: `${sectionHeight}px`, width: `${sectionWidth}px` }}
 			>
 				<div className="notes-header">
-					<div className="drag-boundry 1d top" onDragStart={this.resizeDragStart} draggable="true" style={{ width: `${this.state.width - 30}px` }} />
-					<div className="drag-boundry 2d top-left" />
-					<div className="drag-boundry 2d top-right" />
 					<p>Game Notes</p>
 					<div className="icon-container">
-						<i className="large ban icon" onClick={this.clearNotes} title="Click here to clear notes" />
-						<i className="large window minus icon" onClick={this.dismissNotes} title="Click here to collapse notes" />
+						<i className="large ban icon" onClick={() => changeNotesValue('')} title="Click here to clear notes" />
+						<i className="large window minus icon" onClick={() => dismissNotes(false)} title="Click here to collapse notes" />
 					</div>
 				</div>
-				<textarea style={{ height: this.state.height }} autoFocus spellCheck="false" value={this.props.value} onChange={notesChange} />
+				<textarea style={{ height: this.state.height }} autoFocus spellCheck="false" value={value}
+									onChange={(e) => changeNotesValue(e.target.value)} />
 			</section>
 		);
 	}
 }
 
+Gamenotes.defaultProps = {
+	value: '',
+};
+
 Gamenotes.propTypes = {
-	toggleNotes: PropTypes.func,
+	changeNotesValue: PropTypes.func.isRequired,
+	dismissNotes: PropTypes.func.isRequired,
 	value: PropTypes.string
 };
 
 export default connect(
-	null,
+	() => ({}),
 	mapDispatchToProps
 )(Gamenotes);

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -36,8 +36,7 @@ class Gamechat extends React.Component {
 			chatFilter: 'All',
 			lock: false,
 			claim: '',
-			playersToWhitelist: [],
-			notesEnabled: false
+			playersToWhitelist: []
 		};
 	}
 
@@ -83,10 +82,6 @@ class Gamechat extends React.Component {
 			this.setState({ inputValue: '' });
 			$(this.gameChatInput).blur();
 		}
-
-		if (prevProps.notesActive && !nextProps.notesActive && this.state.notesEnabled) {
-			this.setState({ notesEnabled: false });
-		}
 	}
 
 	handleChatScrolled = () => {
@@ -115,21 +110,6 @@ class Gamechat extends React.Component {
 		const { notesActive, toggleNotes } = this.props;
 
 		toggleNotes(!notesActive);
-		this.setState({ notesEnabled: !notesActive });
-	}
-
-	renderNotes() {
-		if (this.state.notesEnabled) {
-			const notesChange = e => {
-				this.setState({ notesValue: `${e.target.value}` });
-			};
-			return (
-				<section className="notes-container">
-					<p>Notes</p>
-					<textarea autoFocus spellCheck="false" value={this.state.notesValue} onChange={notesChange} />
-				</section>
-			);
-		}
 	}
 
 	handleClickedLeaveGame() {
@@ -635,7 +615,7 @@ class Gamechat extends React.Component {
 					{userInfo.userName && (
 						<i
 							title="Click here to pop out notes"
-							className={this.state.notesEnabled ? 'large window minus icon' : 'large edit icon'}
+							className={this.props.notesActive ? 'large window minus icon' : 'large edit icon'}
 							onClick={this.handleNoteClick}
 						/>
 					)}
@@ -965,7 +945,11 @@ Gamechat.propTypes = {
 	gameInfo: PropTypes.object,
 	socket: PropTypes.object,
 	userList: PropTypes.object,
-	allEmotes: PropTypes.array
+	allEmotes: PropTypes.array,
+	notesActive: PropTypes.bool.isRequired,
+	toggleNotes: PropTypes.func.isRequired,
+	updateUser: PropTypes.func.isRequired,
+	loadReplay: PropTypes.func.isRequired,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Gamechat);


### PR DESCRIPTION
While checking #1049 I noticed that there was much more code related to notes in the codebase that was unused because it was either superseeded or simply not working.

This PR does two things:
- Clean previously used notes rendering from `Gamechat.jsx`. Removing it from the state, having the button react to the changing proptype instead of the state (which in turn updated because of that same prop). Also add missing props to the `propTypes`.
- Clean `Gamenotes.jsx` by moving simple code that just calls an action into the jsx. Simplifying the actions. Also restructured, renamed and removed code that was unused (e.g. `dragOverFn` in the `mapDispatchToProps` and resizing since `resizeDragStart` does nothing)

Let me know what you think of these changes, if they're something you want to have changed at all. I noticed there is a lot of commented and unused code in the repo so I think there are more things like this that could be improved (for example by removing the unused player notes code, because git is version control and you don't need to keep code you have in your history). I've also made a setup with the notes state moved to redux completely (https://github.com/se-bastiaan/secret-hitler/commit/c716982211ab26715927fba85716f1efa71f80c0) but I thought this might be a good start.