### PR TITLE
Patch for issue #1061, veto zone

### DIFF
--- a/docs/Brilliant-Plays.md
+++ b/docs/Brilliant-Plays.md
@@ -1,0 +1,11 @@
+This is a list of plays that have been particularly impressive to either me (gw12346) or other members of the SecretHitler.io Community.
+
+[[Back to the Notes for Newcomers|Notes for Newcomers]]
+
+_This list is incomplete. You can help by expanding this list._
+
+### Scorcha creates a fas-fas conf in a 5p game
+
+Scorcha (seat 1, Hitler) conflicts BoJo (seat 4, Fascist) in a 5p game, making the score 4-3. Scorcha peeks RRR, but claims RBR, and the table topdecks twice, outing Scorcha.  Fas win by a 3rd top-deck, although a more competent BoJo would have won quicker.
+
+Source: [[https://secrethitler.io/game/#/replay/RaspyLethalDogRemake]]

--- a/docs/Current-Meta.md
+++ b/docs/Current-Meta.md
@@ -1,0 +1,24 @@
+This is a list of meta that are currently in use on SecretHitler.io.
+
+[[Click here|Notes for Newcomers]] to return to my notes on basic strategies.
+
+## November 2018
+
+Opening meta is most developed for 7p, 5p (and to a smaller extent 10p) games.
+
+* In 5 player games, the order is either:
+  * 14 41 etc. until a red is played, at which point the govt. becomes 25, 42, 53 or 13, or
+  * 14 41 etc. until the 1st deck finishes (either 5 govts. of 14/41 have passed)
+* In 6 player games, the order is 14 25 36 4-BP.
+* In 7 player games, the order is either:
+  * 15 26 37 45 or 46 if 15 was red, or
+  * 15 26 37 51 etc. (the "skip 4" meta), or
+  * 15 26 51 62 etc.
+* In 8 player games, the order is 15 26 37 48.
+* In 9 player games, the order is 16 27 38 49 5-anyone blue.
+* In 10 player games, the order is 16 27 38 49 5-10.
+
+Investigation meta on drawing RRR is most commonly:
+* Investigating your chancellor;
+
+Investigating another president who also claimed RRR is neither recommended nor widespread.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,927 @@
+![header](https://cdn.discordapp.com/attachments/335071937350860801/357617077881667584/hello1234.jpeg)  
+
+***
+# **Can you find and stop the Secret Hitler?**
+
+**Welcome to The Secret Hitler GitHub page!**
+
+*Go ahead and fork us and give us a star!*
+
+**To clone this wiki locally, run the following command line in your terminal:**
+
+```bash
+git clone https://github.com/cozuya/secret-hitler.wiki.git
+```
+
+*We appreciate any helpful contributions to help improve this wiki to be most useful to the Secret Hitler.io Community.*
+
+### Be sure to follow our **[Terms of Use](https://github.com/cozuya/secret-hitler/wiki/About-Secret-Hitler#terms-of-use-general)** otherwise you can be subject to a ban.
+
+>**Play the [Game!](https://secrethitler.io)**
+
+>**Join us on [Discord!](https://discord.gg/secrethitlerio)**
+
+>**Email the [Developer!](mailto:chris.v.ozols@gmail.com)**
+
+![banner](https://cdn.discordapp.com/attachments/326820032116162561/375862100251115520/image.jpg)  
+***
+
+
+## Player Color Info
+
+**Lobby and player color info:**
+
+Players in the lobby, general chat, and game chat are grey/white until they reach 50 games played. After that, they are known as **"rainbow players"** ![rainbow icon](https://cdn.discordapp.com/attachments/323243744914571264/380130085254070273/rainbownewsmall.png) because their color changes based on their stats. **Rainbow players** have access to play in special **rainbow player only** games.
+
+The color of a **rainbow player** depends on their **ELO**, a type of matchmaking rating. The spectrum of colors goes from ***deep green*** as lowest **ELO** to ***deep purple*** as highest **ELO**, passing through ***yellow*** and ***orange*** on its way.
+
+Additionally, **Administrators** have a ***red*** color with a ***dark red (A)*** and are always at the top of the list. **Editors**, placed at the top just below **Administrators**, have a range of special colors to stand out, as well as a ***red (E).*** **Moderators**, placed at the top below **Editors**, have a ***blue*** color with a ***light red (M).*** Lastly, **Contributors** get a special ***teal*** color as well! Contribute code to this open source project to be endlessly pestered about why you're teal.
+
+## Notes for beginners
+
+Please contribute your own strategies for newcomers to SecretHitler.io in our Wiki [[here|Notes for Newcomers]], [[here|[UNFINISHED] General strategy guide For new players]], and tell us the [[brilliant plays|Brilliant Plays]] you've seen!
+
+## Changelog  
+> ### **Current Version:** *Version 0.15.0 released 10-21-2018*
+
+**New feature: custom games!**
+
+Create a fully customised game to play the game how you want to!
+- Custom Games are always casual, and have a fixed player count as opposed to the selectable range of players.
+- It plays 5 to 10 as usual and must have a liberal majority.
+- Choose if hitler knows his fascists, when hitler zone starts, when veto is enabled, and what policy cards are in the game.
+- There's a new game filter for custom games (filter icon next to the "create a new game" button on the lobby).
+- All of this feature thanks to contributor Hexicube!
+
+**New feature: game filters now save/persist when toggled.**
+
+Other items:
+- User reports should finally be fixed.
+- Dragging the game notes window to bad places should no longer open a new tab.
+- Lack of rainbow color for seasonal elo/WL has been fixed.
+- Game chat messages should no longer use an extra line.
+- Added extra notches to the minimum elo and timed game sliders.
+- Deck shuffles are now shown in game chat.
+- Browser crashes now show an error page instead of a blank screen.
+- BigNose emote is back.
+
+> ### *Version 0.14.14 released 10-16-2018*
+
+**New feature: new players must agree to the terms of use.**
+
+I want to again stress that if you don't agree with the rules of the site (cliffs: don't be an asshole), play elsewhere.
+
+Bugfix: full height player setting now auto-scrolls chat correctly, making it actually usable, thanks to a contributor. Check it out again if you have a large monitor.
+
+Cleanup: emotes have had a review and some of them altered, updated, and removed.
+
+> ### *Version 0.14.13 released 9-29-2018*
+
+**Welcome to season 4!**
+
+The top 10 players of season 3 are:
+
+    Fusilli - 2138
+    SheepManu - 2127
+    HomoSapien - 2068
+    Samsung - 2035
+    benjamin172 - 2031
+    harvyyy - 2025
+    imbapingu - 2014
+    Manu1234 - 1991
+    Jasmine - 1989
+    NotIconic - 1917
+
+**New this season:** the top 5 players of last season now have special badges thanks to mod benjamin172. Unfortunately not a lot to report lately, I've been incredibly busy and haven't had the time. We do have 2 new emotes! LibFrown and FasFrown credit to new contributor PeeOnBus. Also, speed mode is now enabled by default when entering create game credit by contributor LordVader. Thanks for playing!
+
+> ### *Version 0.14.12 released 8-8-2018*
+
+**250,000 games played! Wow!**
+
+**New feature: full height in game player setting**
+
+There's a new setting for players when enabled, the UI will take up the full height of your monitor while in game, greatly extending the chatbox (see below). This will only be apparent for (on 100% browser zoom) players with larger monitors, laptops and smaller will not see any change.
+
+**New feature: moderator manual conclusion of games.**
+
+In a ranked game where someone afks/rage quits at the very end when they're about to lose? Contact a moderator and they can end the game for the team that was about to win, assigning you precious elo points. About time!
+
+**Other stuff:**
+
+ - New emotes! Sheeped, Shepherd, and ThumbsDown. Thanks to contributor JohnCena.
+ - Private/anonymous player names can no longer be seen by hovering on them..
+ - You don't need >1675 seasonal elo to make an elo limited game, overall now works as well.
+ - Contributor color is back.
+ - iOS safari users should be able to use their profile again.
+ - Next major feature planned is custom games, where the game creator can do things like set different policy powers and when hitler zone starts. There's some new polls available, please take a look.
+
+> ### *Version 0.14.10 released 7-20-2018*
+
+ - You can delete people from your blacklist again.
+ - Elo minimum games now lets a player who has either seasonal or overall elo above it play in that game. You still need to have seasons on though (will get to that later).
+ - Some performance optimizations have been put in, hopefully making things more stable.
+
+> ### *Version 0.14.9 released 7-15-2018*
+
+**New feature: elo limiter has gone in.**
+
+Minimum you can set this to is 1675, we'll keep an eye on it.
+
+**Blacklist overhaul (again)**
+
+Several players are using the blacklist feature in an unintended way, causing some grief for everyone. All blacklists have been deleted, and there now is a (working this time..) limit of 10 players that can be on your blacklist at once.
+
+**Timed mode may have its long standing bug fixed thanks to contributor/mod Hexicube.**
+
+**Some changes have been made in the back end that should make some performance increases/less lag and crashes. I hope.**
+
+> ### *Version 0.14.8 released 7-1-2018*
+
+**Welcome to season 3!**
+
+All seasonal elo has been reset to 1600 and all seasonal winrates are 0-0. Season 2 badges have been applied to the top ~75 players of season 2 by elo.
+
+**New feature: elo slider/limiter** (not quite working, will be in this week)
+
+Players above 1700 elo will now see a new slider while creating a game - use this to limit what players can play in the new game you are creating. Players who are under or over the threshold will not be able to sit.
+
+This feature will be watched for feedback - I don't want to lock players out of games, but I also think its nice to be able to play with high elo players exclusively if you want. This feature only applies to seasonal elo right now.
+
+**The terms of use on the about page have been somewhat adjusted. I want to make it clear that abuse by anyone is not allowed. If someone makes a mistake that costs you a game, do not scream at them, do not call them "retards" or "cunts". If so you will eat a ban. Its a free web game with zero stakes, chill and hunt/elect some fascists.**
+
+> ### *Version 0.14.7 released 6-17-2018*
+
+**Verification emails should be fixed.**
+
+**New leaderboard component now has a working link on the lobby.**
+
+**Due to popular demand, verified only games are now default off instead of on.**
+
+> ### *Version 0.14.6 released 6-12-2018*
+
+**New feature: seasonal leaderboards**
+
+Click the big words on the lobby to see who's top elo for the season, and also who's went up the most in the last 24 hours.
+
+**Attempt to fix "verification email goes to spam/sometimes rejected" issue has gone in.**
+
+**Also moderators can now manually set accounts to verified, if you are getting no where with the emails, contact a mod, thanks.**
+
+> ### *Version 0.14.5 released 6-7-2018*
+
+**New feature: email verified accounts**
+
+Your account can now have a new verified status by adding an email, and clicking a link when you receive an email from the site. New players can now (optionally) add their email while signing up. Only non-disposible email providers can be used, and its possible that the site's email will wind up in your spam folder so check there before requesting a new email.
+
+I want to make it very clear that I do not want or will use your email addresses for any reason other than to have it possible to be verified. The terms of use has the following added:
+
+ - Email addresses are used for ONLY the following actions: verifying your account, and reseting your password.
+ - In no circumstances will your email address be used for anything other than the above including any sort of mass "email blast".
+ - Only administrators have access to see your email address.
+ - Your email address will never leave the site/will never be given away or sold.
+
+In addition, you can also change your email address and request a new verification email. Password reset coming soon.
+New game mode: verified accounts only
+
+Verified accounts will now optionally be able to make a game where only other verified accounts can sit in.
+
+> ### *Version 0.14.3 released 6-1-2018*
+
+**New feature: sound pack #2!**
+
+Thanks to contributor straightleft, a new pack of sounds has been implemented, more tonal/synth like. As this is a different type of setting change, if you want to use sound pack #1 or turn your sound off, you'll have to go to your settings screen now.
+
+**Many bug fixes thanks to contributor Hexicube.**
+
+**New feature: enhanced account actions.**
+
+Like a real app, I am implementing some things that should have been done some time ago. In this update, only the delete account action is new, and should work as expected. Soon I will be rolling out email-verified accounts. Don't worry, these will be optional.
+
+*Our terms of use has been updated...*
+
+> ### *Version 0.14.2 released 5-22-2018*
+
+**New feature: sound effects!**
+
+Thanks to contributor Idrissa, most common sounds have a sound effect associated with them. Fun! You can disable these in player settings. This setting does not effect the starting "bong" sound.
+
+Also some bug fix attempts.
+
+> ### *Version 0.14.0 released 5-20-2018*
+
+**New feature:** Elo system
+
+An elo system has come to sh.io. What is it/where is your winrate/why did your color change? See below.
+
+Effectively an elo system is a point-based representation of your weighted skill based off of your teammates and your opponent's elo. The easiest way to think of it is that, when you win a game, your elo will go up more if you are playing against high rated players (their collective average) than low rated players. This is adjusted for the "normal" winrate of your team and the game size.
+
+Player colors for elo mode have been redone - check the information icon on the player list. There is some drastic changes: based off percents, most players will be green. Some will be orange, and a small percent will be purple. Contributor color has been reassigned to teal.
+
+Elo changes will be communicated when a game ends. Remember that all elo is based on the average of your and your opponent's team elo.
+
+This feature can be disabled in your player settings screen.
+
+**Redone blacklists**
+
+All blacklists have been wiped, and a limit of 20 players that can be blacklisted has been applied. This will fail silently if you try to go over that. Blacklists are intended to be a way to avoid players you personally don't like playing with, not to be wielded as a weapon against players you can't control. Some players have blacklists in the hundreds and thats not what the feature was meant for - if there's a player breaking the rules, report them.
+
+> ### *Version 0.13.5 released 4-29-2018*
+
+**New feature: seasonal stats page.**
+Check out the link in the normal stats page to toggle between current season and overall stats.
+
+Other bugfixes to various issues.
+
+> ### *Version 0.13.4 released 4-28-2018*
+
+**Tournaments temporarily disabled, see below.**
+
+**Security update**
+It was brought to my attention that there's some issues with security around certain actions. This update has addressed these issues. Its important to note that these were game related issues, not account: your password is secure and not visible by anyone including me, and important info like who is each role and what the policy deck looks like, is and always was secure.
+
+**Other items**
+ - A bug with the new blacklist modal and deleting entries has been fixed.
+ - There's some new helpful messages when you try to take actions like chat without 2 games played or chat while dead.
+ - The cooldown for remaking games has been changed to 2 seconds if remake is on, and 10 seconds if remake is off.
+ - Several fixes to issues with remaking games have occured.
+ - Some fixes to issues with player colors have been implemented.
+ - Welcome new moderators **littlebird** and **Hexicube**!
+
+**Huge callouts to contributors Hexicube and Nth for a ton of this work!**
+*We don't talk about version 0.13.3*
+
+> ### *Version 0.13.2 released 4-22-2018*
+
+**New feature: expanded timed mode (turbo mode)**
+Want to play a super fast game (or tournament)? The timed mode slider has been changed from 30 second increments to 1 second increments, and the minimum time is now 2 seconds (due to animations, can't be 1 second)! Important note: as the game clearly wasn't meant to be played this way, timed mode games under 30 seconds are forced to be casual games. Have fun! The display in creategame page has been updated slightly.
+
+**Bug fix:** fix to issue with timed mode some times auto choosing chancellor erroneously (I hope, please update if you still see this)
+
+**Other issues**
+ - Previous "timed mode" idea credit to player HREmperor who gets orange contributor color. Contribute to this open source product to get it also! 140+ open issues on github! 😑 
+ - In your profile you can now view everyone on your blacklist, and remove them from it as well by clicking the remove icon. *For reasons I'm not going to get into this will not work if you go to your profile from a direct link/when you're not already on the site.*
+ - There's a new timed mode game filter (funnel icon next to create game button), disable this if you don't want to see timed mode games.
+ - Remake messages in chat no longer say what player has voted to remake it.
+ - The "cooldown" of the remake button being able to be vote for against remake has been moved from 2 seconds to 10 seconds.
+ - To avoid libs abandoning "lost" games, the remake threshold for 6p games is now 5, up from 4.
+ - The whole remake system that was semi-bugged and needed to be rescinded and then revoted in order to get started on remaking may have been fixed? Somehow? I swear I didn't do anything but it seems to be working as intended now. Please update if not.
+ - The stats page works again for 9p rebalanced.
+ - The one time name change feature has been removed, didn't work right and it turned out it wasn't a great idea to begin with.
+ - Replays now show the casual game icon when available.
+ - Casual game tournaments no longer award crowns.
+ - **New emotes:** CantBeBothered and Salty, thanks to contributor LordVader.
+
+> ### *Version 0.13.1 released 4-3-2018*
+
+**New game mode: Timed mode**
+In a timed mode game, a timer on all actions appears in the lower right part of the fascist board, after which the next action is chosen at random.
+
+![Screenshot](https://secrethitler.io/images/timed-mode-example.png)
+
+Example: in a 5 minute timed mode game, if someone does not make a required action in 5 minutes such as voting on an election, their nein or ja vote is chosen for them at random by the server. Note that in order to save stress on the server, this countdown is held client-side and will only be visible to players/observers if they are present in the game when each timer starts (but still goes on in the background on the server, of course). This mode will likely favor fascists! Feedback requested. People abusing this mode to do.. something.. will be subject to moderation action.
+
+Complicated magical changes were made in the back end in order to enable this functionality and it may be subject to.. not being perfect. Please report any problems you see. Hopefully problems != crashes.
+
+**Bug fix: game now once again works on iOS devices. Spoiler: they don't support notifications...**
+**Bug fix: blind mode players cannot reveal their names by pinging other players..**
+
+> ### *Version 0.13.0 released 4-1-2018*
+
+**Season 2 has begun.** Seasonal awards have been implemented: the top 60 players with more than 150 wins in season 1 have been separated into 3 tiers, and receive special award flair on the lines of gold/silver/bronze.
+This flair can be disabled via the disable tournament crowns setting which has been renamed to disable tournament crowns and seasonal awards.
+
+**Congratulations to the top players of season 1 (more than 150 wins):**
+ - maki2 66% wr
+ - karamia 65% wr
+ - TheDaniMan 64% wr
+ - NotIconic 63% wr
+ - TheJustStop0 62% wr
+ - qwefjz 61% wr
+ - BunchOfAnima 60% wr
+ - Zeek 60% wr
+
+**New feature: player notifications (pings)** When you enter the site for the first time, you will receive a notification that looks like this:
+
+![Screenshot](https://secrethitler.io/images/notification-permission.png)
+
+Obviously not localhost..
+
+If you enable this feature, other seated players may now send you (and you may as well) a "wake up" notification. If someone types in "Ping5", the player in seat 5, if notifications are enabled, will see a screen like this (on their operating system, not their browser):
+
+![Screenshot](https://secrethitler.io/images/notification.png)
+
+Players may use the ping feature only once every 3 minutes, and only in games you're seated in that have been started. This feature is only to be used for players who appear AFK - do not abuse this feature. Reminder: if you wind up finding these irritating, you can revoke permission for them in your browser settings.
+
+**New feature: one time name change.** Dislike your old name, but want to keep your stats and profile? Hit the big new big red button on your settings page to change your name. This only works once per account so choose wisely.
+
+**Other items:**
+ - New emotes courtesy of contributor LordVader! ThinkFace, PIZZA, ExpressionlessFace, PopCorn, RedHeart. They are in the popup menu as well of course.
+ - Tournaments now make the usual "bong" noise when they start.
+ - The "rules" page has been updated thanks to a contributor. The big change is a description of common terms used on the site.
+ - Players can now submit up to 3 moderator reports per game, up from 1.
+ - A bug where people with blacklists over 100 will have an error preventing them from adding new blacklists has been fixed.
+ - The planned "timed game mode" and "player notes" feature didn't quite get wrapped up prior to today's update, look for those soon.
+
+> ### *Version 0.12.5 released 2-20-2018*
+
+**Bug fix: replays are back!**
+Thanks to a contribution a long standing bug in replays has been fixed and should work for all recent games.
+
+**New feature: 3 new emojis - ThumbsUp, CNH, and Shrug. Check them out.**
+
+**New feature: casual game mode setting.**
+Select this to play a game where the results do not affect the player's wins or losses.
+
+**Other items:**
+ - Thanks to a contribution, tournament crowns are no longer visible in blind mode.
+ - Please welcome new moderators safi, Wilmeister, and MrEth3real.
+ - Stats for rebalanced (-2 fascist policy) 9 player games might be working tomorrow.. (data collection occurs at 4am)
+ - There's a new poll on the polls page re: length of seasons
+
+> ### *Version 0.12.4 released 2-3-2018*
+
+**New feature: rebalanced 9p games (again).**
+Now, they start with 2 less fascist policies in the deck. The stats page should be updated.
+
+**New feature: games being remade will now show player roles briefly (thanks to Z3r0-K0ol on github.)**
+
+**Other items:**
+ - The site should look a bit better at smaller screen widths outside of games.
+ - The discord widget in general chat now works again.
+ - "Show chats" button in replays works again.
+ - The how to play page on the website has been updated with new content.
+ - Many "behind the scenes" moderation tools have been implemented.
+ - Please welcome new editor Invidia.
+
+> ### *Version 0.12.3 released 1-6-2017*
+
+**New feature: rerebalanced 9p games.**
+
+Due to 9p, even rebalanced, being way too easy for fascists, the newly rebalanced 9p games will have a "phantom" liberal policy already enacted at the start of the game, in addition to one less fascist policy. There will still be 6 liberal policies in the deck to start.
+
+- The broken UI on the playerlist has been fixed.
+- Sorting of grey players on the playerlist had a bug which caused it to be really broken - now fixed.
+- The chat lock scroll issue has been fixed.
+
+> ### *Version 0.12.2 released 1-6-2017*
+
+**New feature: gamechat shows remaining policies (in order) at end of game.**
+
+![remainingpolicies](https://cdn.discordapp.com/attachments/342005757400842242/399262824892989450/remainingpolicies.png)
+
+**New feature: blind mode now works in tournaments.**
+
+**Other items:**
+- Previous update with players with less than 5 games played being unable to chat in general chat or observer mode has been reduced to be just 1 game played.
+- More fixes to replay issues.
+- Blind mode now shows the player's alias when claiming.
+- An internal UI change has taken place, will hopefully resolve some issues with general chat bouncing around for some users and iOS problems as well.   
+
+***
+
+> ### *Version 0.12.1 released 1-3-2017*
+
+- Players with less than 5 completed games can no longer chat in general chat, chat as an observer, or make player reports.
+- Thanks to a contributor, rebalanced games now show up correctly on the status bar while in a game.
+- Blind mode no longer shows tournament crowns..
+- Please welcome new mods RavenCaps and JerMej1s.   
+
+***
+
+> ### *Version 0.12.0 released 12-31-2017*
+
+**New feature: seasonal mode!**
+
+*Important note: your stats are not gone. Read below before panicking.*
+
+Like many other esport games, seasonal mode has come to sh.io. What this means as that there are now two tiers of player records, seasonal (which starts today) and overall. At the beginning of a season, the seasonal tier is wiped of wins and losses, and should last about 3 months (some tweaking may occur).
+
+When you play a game from now on, its result is added to your overall record and your current seasonal record. Seasonal mode is opt-out, and affects you only - go to your player settings screen to disable it, and your and other player's overall records and name colors will be shown to you instead, just like before this patch. Note: players who have achieved rainbow status do not have to play 50 games to play rainbow games in new seasons, and will still have cardbacks enabled. Yes I realize this somewhat paradoxically will make rainbow games non rainbow so to speak at least for some time. Your profile will not be affected, for now.
+
+Some fun rewards/leaderboards/stats for doing well in seasons are planned for the near future.
+
+**Tournament mode re-re-enabled.. we'll see if this one takes..**
+
+**New feature: rainbow games now count towards standard winrate.**
+
+This has been requested a lot lately, we'll see how this goes/how people like it for season 1. The poll on this was split, let’s give this a shot.
+
+**Other items:**
+
+- Thanks to a pull request, the fascist/lib card icons are now randomized correctly i.e. liberal with pencil mustache/snake in a suit fascist can now appear in any game, not just 9/10p games.
+- Thanks to the same PR, claims now are filtered into the "game" internal chat filter.
+- Thanks to a PR, replays have been worked on and fixed! If you see more issues, please alert us. In addition the role cards are no longer all the same at the end of replays.
+- The above work was done by contributor STOshka/AlexSTO. Awesome!
+- In blind mode games, hovering on a player's name no longer shows you who they are..
+- You can now report players in blind mode. Reminder: blind mode is not an excuse to break site rules.
+- In a consensus vote on elections (everyone votes the same), the ja/nein cards are visible for a much shorter period of time, getting on with it.
+- A bug that prevented players from remaking a game more than once has been fixed.
+- The weird selection bug on elections ja/nein has been fixed, was hotfixed about a week ago but you had to have cleared your cache.
+- Say goodbye for now to Santa Hitler.
+
+> ### *Version 0.11.1 released 12-22-2017*
+
+**Tournament mode re-enabled.. we'll see how I messed it up this time.**
+
+**A bug that allowed presidents/chancellors to chat during election period by tabbing to the input bar has been fixed.**
+
+**New chat enhancements! See below.**
+
+- Words surrounded by * (single asterisk) are italic.
+- Words surrounded by ** (double asterisk) are bold.
+- Words surrounded by __ (double underscore) are underlined.
+- Words surrounded by ~~ (double tilde/grave) are stricken through.
+
+**Puts on professional chatroom application developer hat: please note that this only works on __words__, i.e. text that is separated by spaces, not multiple words. If you want that, you'll (for now..) need to surround each word with the above. Also, you can only have one of these effects per word.**
+
+**The "unchangeable election vote" thing is a bug, not a feature, I'll fix that soon.**
+
+***
+
+> ### *Version 0.11.0 released 12-21-2017*
+
+**New feature: tournament mode!**
+When making a game, you now have the option to instead make a new tournament lobby.
+
+![tournament-creategame-slider](https://cdn.discordapp.com/attachments/342005757400842242/393534540787744768/tournament-creategame-slider.png)
+
+The tournament feature will start 2 tables of a game when 14, 16, or 18 people have signed up. When the 2nd game completes, a final table is created with the winners of both games. Please make sure you have the time set aside to play 2 full games before joining a tournament queue. If you're good. ;)
+
+Winners of the final table receive a new crown icon next to their name that lasts for 3 hours, and are sorted to top of the player list under mods. Yes, you can accumulate multiple crowns. Get 3+ and you'll be above mods and editors! But not admins :) ~ >:(
+
+In tournament round one tables, the remake button has turned into a "cancel tournament" button, please use this if there is an afk and both tables will be stopped. Its not an ideal solution but its what we can do.
+
+This feature is a big change, and there's likely going to be issues with it, as my professional QA department is my cat. Other than disable observer chat, you can use all other normal game settings for tournament mode with one caveat - in the unlikely event that you play a 6p final table, it will always be rebalanced.
+
+**New player setting: disable tournament crowns**
+
+Duh.
+
+**Other items**
+- Thanks to contributor Rex1234, you can now access your profile directly by clicking on your name next to the settings cog.
+- Hovering over a player's name in game now shows their name in the "report" description text (in case they have lots of crowns).
+
+**Next up**: any issues with tournaments, and most likely, a 3rd and 4th tier of playerlist sort for tournaments and rainbow tournaments. After that, probably seasons as its a small change and optional and extends the life of the game.   
+
+***
+
+> ### *Version 0.10.7 released 12-18-2017*
+
+**Rebalance update in create game**
+When creating a game, you no longer have the option to rebalance all 6/7/9p games - instead, you can pick individually via new checkboxes which game sizes you would like rebalanced.
+![new-rebalance](https://cdn.discordapp.com/attachments/342005757400842242/392440960174522368/new-rebalance.png)
+
+**Blind mode update**
+Blind mode now assigns every player a random adjective + animal name, instead of just being blank/their number. Please let me know if you find this to be more playable/any other feedback. Also, it no longer shows who is seated or their cardbacks in the gamelist/lobby.
+
+**New create game option: disable observer chat**
+Toggle this on to prevent observers from chatting at all in your new game. No icon for this as thats starting to get huge (though you will see that in these games, the internal chat filter for observers is not present).
+
+**Other items**
+- Gamelist filters now correctly show the toggled state after leaving and coming back to the list, and there is new and obvious UI for that feature.
+- "Show chats" button in replays should work now (no longer crash the browser/require refresh).
+- When you search for a profile from the settings view, your URL will correctly update to show the player's name.
+- Moderators now have a new sitewide "disable game creation" setting - this will be used when planned updates are about to happen. I'm lazy and there's no UI for it, the button will just not do anything so uh don't panic.
+- Players with exactly 50 games played are no longer grey in the player list.
+- There's some chance I completely broke replays in this update... if so please don't hassle me/the mods, I will work on a fix immediately.   
+
+***
+
+> ### *Version 0.10.6 released 12-10-2017*
+
+**New game type: blind mode**
+
+![blind](https://cdn.discordapp.com/attachments/342005757400842242/389599349660844034/blind.png)
+
+Games with this option enabled will anonymize players - players do not have their names displayed (or colors/cardbacks) until the game is complete.
+
+**New gamelist filters**
+New gamelist filters for standard and rainbow games have been added.
+
+**Next major update (tournaments) is almost done, expect this week, the increased traffic was a bit distracting.**   
+
+***
+
+> ### *Version 0.10.5 released 12-9-2017*
+
+**New feature: player blacklist**
+If you'd like to blacklist a player, go to their profile via the playerlist or search from your settings page, and click the new button. This has 2 effects: it prevents them from joining games you have made, and also gives them a new color for you so that you can avoid games they are in. Abuse of this feature for public games will result in a ban.
+
+**New setting and moderation action: converting a player from normal/public to private-game-only**
+If you'd like to be an anonymous player (or not be) you can now toggle this gamesetting (cog icon in upper right) - this can only happen once every 18 hours. This action will log you out.
+
+**New gametype: only private-game-only players allowed**
+For anonymous players, there is a new checkbox while creating a game that only allows other anonymous players to take a seat. Non-anonymous players will not see these games on the list.
+- Private, and private only games now have an icon on the gameslist and in games themselves.
+- Gamelist filters will now remember your settings when leaving and then returning to the gamelist view.   
+
+***
+
+> ### *Version 0.10.4 released 12-6-2017*
+
+**New feature: private-game-only accounts**
+![Private Account Sign-up](https://cdn.discordapp.com/attachments/342005757400842242/388725255109214212/Screenshot_2017-12-08_11.03.31.png)
+When signing up for an account, you can now make a new type of account - one that can only create and sit in private games. That account name does not appear in the userlist on the right sidebar, cannot use general chat, cannot set custom game names, and when a non-moderator views a game that player is playing in, their real username is obscured. Please use these if you're just visiting. Please note that I'm not condoning breaking the site rules, but this is just easier for everyone…
+
+**New feature: gamelist checkbox filters**
+Self explanatory - the increased traffic from our new clover friends have made these necessary. Because I'm lazy and did this quickly you'll have to redo these every time you revert to the gamelist view, sorry. I'll make it persist next patch.
+
+**Other:**
+•	Bug fix: Players seated in a game that has been remade can no longer hit the remake button, screwing everything up/bouncing between games.
+•	Bug fix: Private games that get remade now correctly transfers over the old game's password, as expected.
+•	Bug fix: Observing a game when someone is executed no longer crashes your browser..
+•	Players in private games can no longer report players.
+•	Game UIDs always start with a capital letter.   
+
+***
+
+> ### *Version 0.10.2 released 11-19-2017*
+
+**Bug fix patch:**
+Mobile devices should work better, hopefully fixes to some of the chat scrolling issues, start game sound should be back, gamenotes text readable again.
+
+**Next up: more bug fixes...**   
+
+***
+
+> ### *Version 0.10.1 released 11-14-2017*
+
+**Bug fix patch:**
+- Removed tourney and blind mode from create game - they're not ready yet.
+- Moved some assets from a source (cloudflare) that is not accessible in some countries.
+- You can now scroll while viewing chats in replays.
+- A bug with the way this was deployed for production was resulting in giant js to download, that has been fixed.
+- New favicon! New rainbow icon!
+
+**Next up: more bug fixes...**  
+
+***
+
+> ### *Version 0.10.0 released 11-13-2017*
+
+**New feature: UI overhaul thanks to contributor Wi1son**
+Huge changes! Also updates to some of the more irritating front-end issues like blank screens/bouncing back and forth. Please report any issues you see.
+
+**New feature: see chats in replays.**
+There's a new button on replays to toggle between the replay tools and the chats in that game.
+
+**New feature: rebalanced 7p games.**
+7p games have the optional rebalance treatment now - same as 9p, a fascist policy has been removed to start the game.
+
+**Up next: blind mode and tournament mode!**  
+
+***
+
+> ### *Version 0.9.2 "dim3" released 11-5-2017*
+
+**New feature: discord integration in general chat.**
+
+Click the new discord icon (while logged in) to replace the site's general chat with our discord channel's general chat.
+
+**New feature: disable confetti user setting.**
+
+For those of you that hate fun.
+
+**New feature: moderator sticky notes on general chat.**
+
+Dismiss in usual way, will be used to impart useful information that is less temporary than broadcasts.
+
+**New feature: reverted private games visibility.**
+
+Having them totally hidden was probably too difficult to find for some players that didn't have the URL. So now everyone can see private games again, but only those who are seated (and mods) can see gamechats. A decent compromise I think.
+
+**Other issues:**
+
+- Clicking on a player's name in general chat takes you to their profile page.
+- The remake button's gamechat now tells you how many votes you need to remake a game.
+- A fix to moderation timeout ability is in.
+- Players can only make one player report per game. I'm lazy and there's no failure state for this, so just keep it in mind: *more than one attempt per game will not go through to mods.*
+
+***
+
+> ### *Version 0.9.1 "dim2" released 11-2-2017*
+
+**New feature: remake game button**
+
+![remake](https://cdn.discordapp.com/attachments/342005757400842242/375836350223745026/remake.png)
+
+Your game is dead or afk'ed on, or you just want to play again with the same team? Hit this button in the lower left corner of the fascist track to show that you'd like to remake the game. When (number of fascists in game +1, or +2 in 8, 9 and 10p games) have also hit the button, the game is remade with the same rules and name and updated UID/link, and will start when its requirements are met as usual.
+
+**New feature: rerebalanced 9p games**
+
+In what should speak volumes about what I know about game design, having an already-enacted liberal policy in 9p games.. actually makes fascists win more. So now that's gone, but there is one less fascist policy in the deck (so starting at 16). We'll see what happens there.
+
+**Other issues:**
+- Thanks to a contribution, "blind mode" aka no gamechat mode now correctly will let other fascists see who is on their team.
+- Stats/charts should work with the new rerebalanced 9p starting tomorrow when data collection fires at 4am.  
+
+***
+
+> ### *Version 0.9.0 "dim" released 10-28-2017*
+
+**New feature: player bios**
+
+![bio](https://cdn.discordapp.com/attachments/342005757400842242/374314464549273600/bio.png)
+
+Visit your profile page to write something brief about yourself that others can see. Links are allowed, but SEO unfriendly (google "nofollow noreferrer noopener"). Obviously still subject to the site terms of use...
+
+**New feature: optional rebalancing for 6 and 9 player games**
+
+There's a new create game option (default: on) that, when a 6 or 9p game has begun, a facist and liberal policy have already been enacted, respectively. You'll get it. While these are being recorded correctly, there are no stats/graphs for this yet - next minor update.
+
+**New feature: URL routing**
+
+What this means is the URL of your browser now accurately shows the state of the application. The big takeaway is games, replays, and profiles are now all deep linkable! Make a private game and want your friends to join? Just send them the link. The browser back and forward buttons now work in the way you would expect as well. If you link a game that no longer exists, you will instead be routed to the replay. This required a large change to the front end and may not be perfect, please update if so. Also using gfycat style naming convention for game IDs!
+
+**New feature: actual private games**
+
+Private games have been changed - they no longer show up on the list of games on the left sidebar, and are only accessible through the new URL linking mechanism. In addition, private games no longer count towards a player's win and loss rate. Note: moderators can still see private games. I realize that it may be somewhat difficult to play additional private games - next minor patch will have a remake game feature which will help with that.
+
+**Other issues:**
+
+- Overall UI has been tweaked color wise mostly. If you've been playing here at all in the past year (yikes), you'd know I am not at all a designer, but I can at least attempt to make things more fluid and contiguous. If you ARE a designer (and want to work for free..), let me know.
+- Links in general chat to sh.io itself, or to this site's github repository, are now clickable. Other links are still not.
+- Hovering on a chat in general chat will show a timestamp of when it was said.
+- The whitelist feature now correctly has a scroll bar.
+- If you have a custom width or font, the application no longer "flashes" when you load the page.
+- A fix to players being able to make accounts with the same name but different capitalization has been implemented.
+- The stats page is finally working right - it updates once per day, and the undefined/NaN stuff is gone.
+- There is a now a slight UI difference between players who have left a game, and players who are disconnected.
+- All dependencies updated including moving to the latest version of React (16). What this means is hopefully some better front-end performance.
+
+**Up next: the remake game functionality will be finished up and rolled out in 0.9.1. Also new stats graphs for the rebalanced game feature.**  
+
+***
+
+> ### *Version 0.8.2 "blue steel" released 9-30-2017*
+
+**New feature: player selectable fonts**
+
+![fonts](https://cdn.discordapp.com/attachments/362000237209845780/363869012024623104/fonts.png)
+These can be found on the usual place (player settings, cog icon in upper right) and save on click. You will probably want to tweak your gamechat font size slider as well.
+
+- The "game countdown is negative" bug should be fixed.
+- An issue with some players cannot remake an account after it being deleted has been addressed. Contact a moderator if you have been affected.
+- All new images from 0.8.0 have had their saturation knocked down by 25%, and new colors in gamechat muted more.
+- Broadcasts now echo through webhook to [discord](https://discord.gg/zGWtW64).
+
+***
+
+> ### *Version 0.8.1 "silver" released 9-28-2017*
+
+Cleanup/bug fix patch, the following was affected:
+
+- Games should start and stop better now - if a 5th player is seated in a 5-10 player game, and then leaves, previously it would count down from 20 and then stall, now it will correctly not count down and go back to the waiting phase. Awesome!
+- Ages old fix to a special election president being able to nominate a chancellor who was in the last elected government, in opposition to the printed rules.
+- You can now claim after a veto.
+- Fixed a bug where sometimes a president can not select a card to veto, hanging the game.
+- Some more attempts to fix the various small sorting/jumping issues that are still out there.
+- The link in the signup modal on the main page is finally working..
+- Generalchat sticky scroll should work/work better
+- Moderators have ban back, and hopefully some issues fixed with IPs.
+- The info icon on the lobby has been updated.
+- Profile search now works on Edge.
+- There's a new discord webhook to ping admins when the site crashes. -_-
+
+The first 6 issues all done by contributor andy013 on GitHub!  
+
+***
+
+> ### *Version 0.8.0 "citehtseawen" released 9-23-2017*
+
+**New feature: UI overhaul**
+
+Thanks to contributor andy013, most of the cards and images in game have been upgraded and colorized. Neat!
+
+Also fonts redone, many other UI tweaks in. Let us know what you think. Change is good people.
+
+**New feature: chat emotes!**
+
+In twitch.tv style, players can chat small word fragments which will turn into icons inside of chat, such as:
+
+![Emotes InGame Example](https://cdn.discordapp.com/attachments/342005757400842242/361212679953842188/emotes_example.png)
+
+Typically a clickable popup will be available and selectable.. I didn't get to that - next patch. For now, please check out our [emote reference](https://github.com/cozuya/secret-hitler/wiki/Emotes). Thanks goes out to contributor andy013!
+
+**New feature: election voting rework (changable votes)**
+
+Previously, a vote on a government was immediate and permanent. Now, clicking on ja or nein will remove your loader gif, but you can either a) click the selected one again to bring back the loader and prevent vote tallying or just b) select the other option to switch your vote. Votes are tallied as usual when all players have selected their vote.
+
+**New feature: 2nd tier of player moderators (editors) and many new helpful moderation tools implemented.**
+
+Editors will have an (E) next to their name, and mysterious expanded mod powers! Like assign roles to players, and reveal all roles to themselves. Just kidding. Editors and mods can now do helpful things like temporarily turn off account creation in case of troll attack and disable ip bans so that a group from one location can get around the 1 account per day limit.
+
+**New feature: wiki page**
+
+Check out our [wiki page](https://github.com/cozuya/secret-hitler/wiki) kindly set up by editor DFinn. Useful and topical information will be kept there, keep an eye on it if you are interested in the future of this site.
+
+**Other issues**
+
+- Home page and about us page text has been updated and the webform deprecated. If you have feedback/issues, a new email address has been set up in the about page and we are always available via discord and the player report feature.
+- Gamenotes clear button now works.
+- Thanks to contributor jonnybest, hovering on a game on the list in the left sidebar now shows you who is seated in that game.
+- A bug in "blind mode" (no gamechat) was causing fascists to get credit for winning the game when Hitler was shot, this mode was previously disabled via hotfix, now that bug has been fixed and that mode has been re-enabled.
+- Private games "P" icon in the upper left corner of a gamelist was disappearing after the game started - thanks to contributor jonnybest, this has been fixed.
+- Players can now search/type in other players to look at their profile just like clicking on them. The player settings page (gear icon) has this new input field.
+- The footer bar in the default view has been updated to include our wiki.
+- No new polls this release.
+
+*Next up: its high time some more effort was put in to prevent or at least lesson the pain of AFKing players. Also player notes and tournament mode coming soon!*  
+
+***
+
+> ### *Version 0.7.7 "shadow2" released 9-14-2017*
+
+- Terms of use have been updated - if you're playing a public game, you must converse in a language everyone understands.
+- Fix to gamenotes being cleared/deleted every time its dismissed. It will now persist until you leave the site/reload.
+- Gamechat text for the veto policy power has been clarified/expanded for the president & chancellor.
+- More attempted fixes to sort issues in general.
+- The minimum width of this application has been lowered by 30px, meaning it will fit on a laptop like a macbook better without small horizontal scrolling.
+- Some crash fixes attempted.
+- Players can only make one account per day per IP.
+
+***
+
+> ### *Version 0.7.5 "shadow" released 9-10-2017*
+
+***Over 50,000 games have been played!***
+
+**New feature: game notes**
+
+Click on the note icon next to the lock button to pop out a new component you can take notes on, scratchpad style. You can drag and drop this to any location. Not currently resizable as that's a bit tough.
+
+**New feature: sticky chat v2**
+
+Now, when chat is scrolled from the bottom, the lock is automatically set, meaning it will no longer "jump" every time someone chats something new. Conversely the lock is unset when you scroll back to the bottom. Hopefully this will go better than last time which was bugged for many players/browsers/zoom levels I believe.
+
+**Other items:**
+
+- New [polls](https://www.secrethitler.io/polls) have been added, please use them.
+
+- The terms of use has been updated - TOR users are no longer permitted. If you have a legitimate reason to use TOR, contact a moderator.
+
+- Per the polls result, fascist players can no longer shoot hitler.
+
+- The home page now shows how many players are online.
+
+- Swastika symbols can no longer be used for game names..
+
+- Player profiles now include cardbacks.
+
+- Games now show the name and player count.
+
+- Some more attempts to fix sorting bugs have been implemented.
+
+- The link to [discord](https://discord.gg/wCfXkMd) on the default screen & homepage has been fixed.  
+
+***
+
+> ### *Version 0.7.4 "grey2" released 9-2-2017*
+
+**New feature: [polls page](https://www.secrethitler.io/polls).**
+
+I'd like to start getting more feedback from the community so will start adding polls and see how it goes.
+
+**New feature: player reports now also get sent to a new discord channel. Internet is magic.**
+
+**New feature: sticky chat**
+
+Now, when chat is scrolled from the bottom, the lock is automatically set, meaning it will no longer "jump" every time someone chats something new. Conversely the lock is unset when you scroll back to the bottom.
+
+**Other items**
+
+- Experienced mode is now correctly changed to speed mode in the games list.
+- Mod notes now show players.
+- Players can no longer chat blank lines by hitting space.
+- Banned players will have their general chats instantly deleted.
+- Note that the way this app works on the dev side has changed slightly, if you are playing along at home please check the [README](https://github.com/cozuya/secret-hitler#secret-hitler). You'll also need to do npm i this patch.  
+
+***
+
+> ### *Version 0.7.3 "grey" released 9-1-2017*
+
+**New feature: player reports**
+Double click a player's name in game (not card) to bring up an input field to alert moderators of bad behavior. Moderators now see a new icon that shows player reports and will respond when available.
+
+**Feature: stats page**
+The [stats page](https://secrethitler.io/stats) has been (mostly) restored, still needs a little work (undefined/not a number).
+
+**Other items:**
+
+- Bug fix: a long standing bug preventing moderators from properly banning users who are not in game has been fixed.
+- Bug fix: the italic font is no longer semibold.
+
+***Over 400 players have cardbacks! Wow!***  
+
+***
+
+> ### *Version 0.7.2 "black3" released 8-10-2017*
+
+- New game setting: disable player cardbacks. For those who find them distracting.
+- New game setting: application width slider. Prefer the old (or custom) width of the application? Move this slider as desired.
+- Bug fix: winning players can now click leave game as before. Sorry about that!
+
+*New mods: snake69sus & Ecoturtle*  
+
+***
+
+> ### *Version 0.7.1 "black2" released 8-10-2017*
+
+- Players that have a custom cardback now correctly shows the red X when dead.
+- General chat width is now working correctly.  
+
+***
+
+> ### *Version 0.7.0 "black" released 8-7-2017*
+
+**New feature: player uploaded custom cardbacks!**
+
+In the settings view (cog icon in upper right), players now have the option to upload a new cardback that will be shown in-game. The details are:
+
+- Image uploaded must be 70px by 95px, or it will not look right. Do not trust the previewer - it will crunch to fit the box, the game itself won't do that.
+- Rainbow players only.
+- For today only, you can upload an image every 30 seconds. Then it will be limited to once upload an image once per 18 hours. Be careful before hitting save.
+- Only png, jpg, and jpeg are permitted. Must be below 40kb.
+- No NSFW images, nazi anything, or images from the site itself to be tricky. The terms of service page has been updated.
+
+**New feature: better support for large width monitors.**
+
+The application is no longer fixed width, and will stretch to fit the entire screen. Chat boxes will take up the remaining space. I recommend turning "show right sidebar in game" on.
+
+**New feature: enhanced moderator actions**
+
+Mods can now delete users, set wins and losses, and delete cardbacks. Also they can now type in player names to affect offline players. Lets hope they're not fascists.
+
+**Other stuff:**
+
+- The "chat a blank line" bug was fixed.
+- Observer count was removed as it never worked right anyways.
+- Moderators can chat in observer chat in private games.  
+
+***
+
+> ### *Version 0.6.6 "tuotuc" released 8-2-2017*
+
+**Small patch to fix a bug that could be used to crash the server thanks to player veggiemanz who now has a shiny orange name. Also these things:**
+
+- Shuffling of the deck when its less than 3 should now happen before any election, as per the rules. This will prevent the "nein all" problem when there's few policies left.
+- As you probably saw, there is a notice on the sign in/sign up modals to use Chrome or Firefox for the best experience.
+- Fascists who investigate Hitler will not have Hitler's name change to fascist color.
+-Hid the card back section on settings as that is work in progress.
+-Gamelist sort should be better and no longer bounce around as much.
+-Confetti should no longer prevent the winners from being able to type in chat while its raining down.
+-A fix to chancellor discards not showing up in replays.  
+
+***
+
+> ### *Version 0.6.0 "noise" released 6-12-2017*
+
+**New feature: Player profiles**
+
+Click on a player in the lobby/player list to get detailed information about games they've played. You can access your own stats that way, or through the game settings screen ("gear" icon in upper right corner).
+
+A big change to the back end, and will allow for some more interesting features (like game replays) and analysis in the future.
+
+This is an epoch event, meaning that only games from here on out will be seen in your profile.
+
+**New feature: notification for patch notes**
+
+As you've probably seen, the lizard image in the middle will glow until you click it, showing this changelog.
+
+Both features courtesy of contributor jbasrai.
+
+*Please welcome new moderators Jazz and Max.*  
+
+***
+
+> ### *Version 0.5.0 "glow" released 6-10-2017*
+
+**New feature: Player moderation**
+
+Some players have volunteered to be moderators. They are empowered to have the ability to ban non-rainbow players for griefing and trolling, and to check for cheating. Hopefully this (and some more advanced powers from admins) will be a permanent solution to problems that may come up. Moderators will have a red (M) next to their names.
+
+**Other updates:**
+
+- A fix to the rainbow game icon on the gamelist only being there for games that haven't started yet.
+- A fix (finally) to dead players being able to chat by leaving the game and coming back.
+- A 3 second delay has been implemented between the enactment of a policy by the chancellor, and the ability for the government to make a claim (for non-experienced games only). This should change game play a lot I think..
+- Various tooltips have been added to some items and will continue to be addded in the future.
+- A fix to rainbow losses also adding to normal losses, but not the other way around. I'll see if there's a way to credit those.
+- Contribution by player sethe: a fix to the (relatively rare) problem of the election tracker not working right with vetos and neins.
+
+Up next: player profiles. This is just about ready to go and will be released within the next 2 days.  
+
+***
+
+> ###  *Version 0.4.0 "chestnut" released 6-5-2017*
+**New feature: Rainbow games.**
+
+While creating a game, players with more than 50 completed games ("rainbow players") will now be able to create games that only other rainbow players can be seated in. These games have a special symbol in the sidebar.
+
+![gamelist rainbow](https://cdn.discordapp.com/attachments/342005757400842242/358021948716089344/gamelist-rainbow.png)
+
+In the lobby, a new icon appears showing what game style you are filter and sorting the userlist by. Click it to switch 
+between "regular" and "rainbow". Effectively, rainbow players get to "start over" in an optional hard mode with a 0-0 score.
+For rainbow games, your wins and losses are in a different tier, that does not affect your regular game winrate or player color. "Rainbow rewards" may come in at some point.
+
+Also in this release, the karma system has been temporarily disabled due to griefers exploiting it. The next major feature is player moderation, where I will be enlisting some of our regular players to help out in getting rid of griefers and trolls. This isn't all that hard and will be coming soon, and hopefully guarantee a better playing experience for everyone. Please check the GitHub issue if you are interested in helping out.

--- a/docs/Notes-for-Newcomers.md
+++ b/docs/Notes-for-Newcomers.md
@@ -1,0 +1,173 @@
+These notes are from are from my own experience playing on SecretHitler.io and watching high-ELO games there. I hope these notes give you some idea of what the more recent strategies for both teams are.
+
+I assume some basic knowledge of the game already: there is a glossary [here]() for any terms I use that are unknown to the reader. As a result, these notes are not comprehensive, but instead focus on strategies and considerations that are less well known to newer players.
+
+That being said, at the end of the day SH is just a game, and the goal remains to have fun.
+
+### Contents
+* [[Why people insist on a Meta|Notes for Newcomers#Why people insist on a Meta]]
+  * [[The current meta is...|Notes for Newcomers#The current meta is...]]
+* [[A word on the Hitler Zone, the Special Election, and Gunpoints.|Notes for Newcomers#A word on the Hitler Zone, the Special Election, and Gunpoints]]
+  * [[Hitler Zone|Notes for Newcomers#Hitler Zone]]
+  * [[The Special Election|Notes for Newcomers#Special Election]]
+  * [[The Gunpoint|Notes for Newcomers#Gunpoint]]
+* [[Card Counting|Notes for Newcomers#Card Counting]]
+  * [[As a Liberal|Notes for Newcomers#As a Liberal]]
+  * [[As a Fascist|Notes for Newcomers#As a Fascist]]
+  * [[Claimed Decks|Notes for Newcomers#Claimed Decks]]
+* [[Conflicts|Notes for Newcomers#Conflicts]]
+  * [[Delayed Conflicts|Notes for Newcomers#Delayed Conflicts]]
+  * [[Counting the Number of Conflicts|Notes for Newcomers#Counting the Number of Conflicts]]
+* [[Misc Tips|Notes for Newcomers#Misc Tips]]
+
+
+# Why people insist on a Meta
+On SecretHitler.io, people tend to insist on a "Meta" (_i.e._ a set of conventions as to who should you nominate as chancellor? who should you investigate as president?) Metas are considered by some to be controversial, but I think they help the game develop.
+
+When liberals deviate from the meta, _it's a crapshoot_. Occasionally you get lucky, and you improve your winning chances. Yet other times, you probably made things worse. But when fascists deviate from the meta, they'll pretend they deviated randomly, but _they **always** deviate in a way that helps fascists._
+
+So if you allow deviations, fascists can take advantage: liberals can't.
+
+If you see someone deviating from the meta, they're either a lib, and the deviation could be good or bad, or they're a fascist, and the deviation is always bad. If you're more competitive, you assume that nothing is ever accidental, and they're hurting the liberal team, and they're not accidentally hurting the liberal team, etc., etc., and so they're probably a fascist. 
+
+[[ [back to top]|Notes for Newcomers]]
+
+## The current meta is...
+...on a different page [[here|Current Meta]]. Every so often, a slightly newer meta that helps liberals a bit more than normal is "discovered".
+
+[[ [back to top]|Notes for Newcomers]]
+
+# A word on the Hitler Zone, the Special Election, and Gunpoints.
+
+## Hitler Zone
+**Focus on the presidency, and get the _most liberal guy_ in the presidency.** The chancellery will take care of itself. _This is true regardless of which team you are on._
+
+Liberals have two things to worry about in the Hitler Zone. One, that Hitler gets elected chancellor. Two, that a fascist president gets elected. One seems much scarier than Two, but Two is _much more important_ than One.
+
+Firstly, unless you are _extremely_ good, you probably can't tell who Hitler is. Hitler can be quiet or loud, he can be more of a leader, and he can be more of a follower. **You just have to live with the risk of a Hitler election**. Unless you realise this, it is far too easy for a fascist to scare people off a liberal chancellor by insinuating that they might be Hitler.
+
+What's the problem with having a fascist elected president? Well, recall that any president in a government that plays the 4th or 5th red gets to shoot somebody. And the chances of drawing RRR or RRB are good enough for fas that electing a fascist president in the Hitler Zone is usually game winning for the fascists. 
+
+In a 5p, 7p, or 9p game, shooting a liberal means that the liberals no longer have a majority, and fascists now have a 2nd game-winning strategy if they cannot or don't want to pretend to be liberals anymore: _fascists can top-deck to the end._ 
+  * _The odds of fascists winning via top-decking range from over two-thirds (when the score is 4-4) to 75% (4-5) to virtually 100% (there are less than 4 blues already enacted or other special circumstances)._
+
+The fascist strategy is split between trying to install a Fascist or Hitler as president and trying to elect Hitler as chancellor. 
+
+The liberal strategy is to stop Fascists from taking the Presidency.
+
+[[ [back to top]|Notes for Newcomers]]
+
+## Special Election
+As a liberal, **You should always Special-Elect the most liberal player to be president**. If you trust them enough to give them a potential bullet, then you should also trust that they won't deliberately nominate Hitler as chancellor. Trust their judgement here. 
+
+If, however, the president whose govt. played the 3rd red Special-Elects a president who claimed RRR or somebody in conflict, and the table „nein“s the SE'ed president, the SE is said to have been _thrown_. In fact, anyone who chooses somebody dodgy to SE is probably a fascist.
+
+With all due respect to tartanllama, who recommended making the most trusted player chancellor and giving the presidency to somebody else, it is usually far better to avoid a slow and certain death via top-decking than to be paranoid of accidentally dying by electing Hitler chancellor.
+
+[[ [back to top]|Notes for Newcomers]]
+
+## Gunpoint
+
+If everybody agrees that a certain person is the most likely to be liberal, the table might let that person _gunpoint_ someone else. 
+
+That is, the president and chancellor both get elected, and if the president draws RRB and gives his or her chancellor RB, either the chancellor plays the blue, or the chancellor plays the red, at which point the president can execute him. Obviously, if the president draws RBB he simply forces BB, and if the president draws RRR then well, it didn't matter who the president nominated.
+
+**As long as you trust the president, you can „ja“ even if you are certain that his or her chancellor is fascist.**
+
+[[ [back to top]|Notes for Newcomers]]
+
+# Card Counting
+In an ordinary game, there are **6 blues** and **11 reds** in the deck. After five govts. pass, the deck is reshuffled. (If you like, you can take 11 hearts and 6 spades, shuffle them, and see how many spades you tend to get in the first 15 cards.) 
+
+Roughly half the time, you will get **5 blues** in the first **15 cards** / **5 govts**; another half, you will get **6 blues**. Very rarely, (about 11% of the time), you will get only **4 blues**. This is the natural deck, and this is what fascists work with.
+
+[[ [back to top]|Notes for Newcomers]]
+
+## As a liberal
+**Pay attention to the deck.**
+
+Always force (pass "BB") to your chancellor if you draw "RBB". If you give your chancellor "RB", you should be and will be under continued suspicion that you made a blue up, and makes it that much harder for liberals to verify what you really drew. If you force, two people (you and your chancellor) can confirm that two blues have been seen. 
+
+If you give your chancellor a choice and they play the red instead, this is terrible, and any loss will be blamed on you.
+_The normal price for a conflict is the loss of one blue. The price of gaining information through a conflict **through the loss of two blues is way too high.**_
+
+A common and generally accepted behaviour is to claim "RBB" when you drew "BBB" even as a liberal. There is no consensus as to the extent to which this lie helps or hurts liberals.
+
+[[ [back to top]|Notes for Newcomers]]
+
+## As a fascist
+**Pay attention to the deck.**
+
+Work out when to gain trust, possibly at the cost of playing a blue, and when to play a red, which is actually your formal job. 
+
+Claiming RRB when you drew RBB increases trust on you and your chancellor while making any presidents who claimed RRR a bit more suspicious.
+
+If you're Hitler and you receive RBB, you can discard a blue. If your chancellor plays the red, you cover your fascist by claiming RRR. If your chancellor plays the blue, however, you can claim to have drawn RRB.
+
+If your government is fas-fas and the president draws RRB, it is possible for both players in the govt. to lie and claim RBB and BB respectively.
+
+[[ [back to top]|Notes for Newcomers]]
+
+## Claimed decks
+These are how many blues the first five governments claim to have seen.
+
+### 7 blue deck
+This is a deck that cannot occur naturally. Somebody has overclaimed (claimed to have drawn more blues than they really have), probably to provide some cover to a fascist teammate who can then claim "RRR". Those presidents whose chancellors are unable to provide verification are most likely to be under suspicion, like presidents who claim BBB, presidents who claim to have given a choice to their chancellors, or presidents who claim RRB and have conflicted with their chancellors.
+
+### 6 blue deck
+This is a very good deck for liberals. There will be little to no blame placed on any RRR presidents: they still won't look liberal, but they won't look fas either.
+
+### 5 blue deck
+This is a fair deck for liberals. You probably half-suspect that somebody _underclaimed_ (drew "RBB" but only claimed "RBB"), but things are still looking fine. You probably play people who played blues quite preferentially over anybody who's claimed RRR though.
+
+### 4 blue deck
+This is where things get serious. Since naturally occurring **4 blue** decks are so rare, you assume that any RRR president could have dropped a blue, or that a fascist has underclaimed. You do not nominate or play any president who claimed RRR.
+
+### 3 blue deck
+This is a deck that cannot occur naturally. The game is almost certainly in the Hitler Zone after five governments. Scream at every RRR president, interrogate every RRB president, and intimidate every RBB president. I assume that you, the reader, are yourself beyond reproach at this point. There is no way on earth you even remotely trust any president or chancellor who was part of a RRR government.
+
+[[ [back to top]|Notes for Newcomers]]
+
+# Conflicts
+If two people accuse each other of being fascist, do not take sides. Liberals shouldn't know who to trust, and therefore fascists should pretend they don't know who to trust either. 
+
+That said, as the game continues, based on voting and behaviour, you should probably have some inclination _but very rarely_ complete certainty.
+
+[[ [back to top]|Notes for Newcomers]]
+
+### Delayed Conflicts
+Delayed Conflicts work for both teams. Honestly, they usually help fascists more than they do libs, so _delayed conflicts_ and _fake conflicts_ are never held for very long at higher ELO level games.
+
+[[ [back to top]|Notes for Newcomers]]
+
+### Counting the Number of Conflicts
+Be aware of how many conflicts there are at any point. For example, in a 7p or 8p game, there are only three fascists, so if there are three conflicts, then you should have one or two confirmed/guaranteed liberals.
+
+Bearing in mind the number of conflicts also helps you when you are mentally weighing up possible fascist teams.
+
+[[ [back to top]|Notes for Newcomers]]
+
+# Misc Tips
+## Peeking at the Deck [5/6p]
+
+If the peek is claimed to be Blue-something-something, you should Top-deck. Either you get a free blue or the president who peeked is outed as fascist. _Having a confirmed outed fascist is a significant disadvantage in a 5 or 6 player game._
+
+If the peek is claimed to be Red-Blue-something, you can still consider Top-decking.
+
+If the peek is claimed to be Red-Red-Blue, _be aware that liberals can lose if the peek is actually RRR._
+
+[[ [back to top]|Notes for Newcomers]]
+
+## Veto Zone
+
+In the veto zone, unless a president draws RBB, **liberals need a govt. of a liberal president and a liberal chancellor** in order to not lose immediately. In particular, the orientation of the govt. does not matter, _i.e._ XY = YX. 
+
+As a result, Confirmed Not-Hitlers become less important, because the risk of a fascist victory through passing 6 fascist policies outweighs the risk of electing Hitler chancellor.
+
+[[ [back to top]|Notes for Newcomers]]
+
+## Irrational voting
+
+One of the most common ways for liberals to figure out what the fascist team is when an inexperienced fascist team votes as a bloc. The further along the game is, the more likely it is that the voting blocs reflect the teams.
+
+[[ [back to top]|Notes for Newcomers]]

--- a/routes/socket/game/election.js
+++ b/routes/socket/game/election.js
@@ -16,6 +16,9 @@ const { completeGame } = require('./end-game');
 const _ = require('lodash');
 const { makeReport } = require('../report.js');
 
+let ChancellorRejectsVeto;
+ChancellorRejectsVeto = false;
+
 const powerMapping = {
 	investigate: [investigateLoyalty, 'The president must investigate the party membership of another player.'],
 	deckpeek: [policyPeek, 'The president must examine the top 3 policies.'],
@@ -117,142 +120,154 @@ const enactPolicy = (game, team) => {
 
 	sendInProgressGameUpdate(game, true);
 
-	setTimeout(() => {
-		game.trackState.enactedPolicies[index].isFlipped = true;
-		game.gameState.audioCue = team === 'liberal' ? 'enactPolicyL' : 'enactPolicyF';
-		sendInProgressGameUpdate(game, true);
-	}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 300 : 2000);
+	setTimeout(
+		() => {
+			game.trackState.enactedPolicies[index].isFlipped = true;
+			game.gameState.audioCue = team === 'liberal' ? 'enactPolicyL' : 'enactPolicyF';
+			sendInProgressGameUpdate(game, true);
+		},
+		process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 300 : 2000
+	);
 
-	setTimeout(() => {
-		game.gameState.audioCue = '';
-		const chat = {
-			timestamp: new Date(),
-			gameChat: true,
-			chat: [
-				{ text: 'A ' },
-				{
-					text: team === 'liberal' ? 'liberal' : 'fascist',
-					type: team === 'liberal' ? 'liberal' : 'fascist'
-				},
-				{
-					text: ` policy has been enacted. (${
-						team === 'liberal' ? game.trackState.liberalPolicyCount.toString() : game.trackState.fascistPolicyCount.toString()
-					}/${team === 'liberal' ? '5' : '6'})`
-				}
-			]
-		};
-		const addPreviousGovernmentStatus = () => {
-			game.publicPlayersState.forEach(player => {
-				if (player.previousGovernmentStatus) {
-					player.previousGovernmentStatus = '';
-				}
-			});
-
-			if (game.trackState.electionTrackerCount <= 2 && game.publicPlayersState.findIndex(player => player.governmentStatus === 'isChancellor') > -1) {
-				game.publicPlayersState[game.gameState.presidentIndex].previousGovernmentStatus = 'wasPresident';
-				game.publicPlayersState[game.publicPlayersState.findIndex(player => player.governmentStatus === 'isChancellor')].previousGovernmentStatus =
-					'wasChancellor';
-			}
-		};
-		const powerToEnact =
-			team === 'fascist'
-				? game.customGameSettings.enabled
-					? powerMapping[game.customGameSettings.powers[game.trackState.fascistPolicyCount - 1]]
-					: presidentPowers[game.general.type][game.trackState.fascistPolicyCount - 1]
-				: null;
-
-		game.trackState.enactedPolicies[index].position =
-			team === 'liberal' ? `liberal${game.trackState.liberalPolicyCount}` : `fascist${game.trackState.fascistPolicyCount}`;
-
-		if (!game.general.disableGamechat) {
-			game.private.seatedPlayers.forEach(player => {
-				player.gameChats.push(chat);
-			});
-
-			game.private.unSeatedGameChats.push(chat);
-		}
-
-		if (game.trackState.liberalPolicyCount === 5 || game.trackState.fascistPolicyCount === 6) {
-			game.publicPlayersState.forEach((player, i) => {
-				player.cardStatus.cardFront = 'secretrole';
-				player.cardStatus.cardBack = game.private.seatedPlayers[i].role;
-				player.cardStatus.cardDisplayed = true;
-				player.cardStatus.isFlipped = false;
-			});
-
-			sendInProgressGameUpdate(game);
-
-			game.gameState.audioCue = game.trackState.liberalPolicyCount === 5 ? 'liberalsWin' : 'fascistsWin';
-			setTimeout(() => {
-				game.publicPlayersState.forEach((player, i) => {
-					player.cardStatus.isFlipped = true;
-				});
-				game.gameState.audioCue = '';
-				if (process.env.NODE_ENV === 'development') {
-					completeGame(game, game.trackState.liberalPolicyCount === 1 ? 'liberal' : 'fascist');
-				} else {
-					completeGame(game, game.trackState.liberalPolicyCount === 5 ? 'liberal' : 'fascist');
-				}
-			}, process.env.NODE_ENV === 'development' ? 100 : 2000);
-		} else if (powerToEnact && game.trackState.electionTrackerCount <= 2) {
+	setTimeout(
+		() => {
+			game.gameState.audioCue = '';
 			const chat = {
 				timestamp: new Date(),
 				gameChat: true,
-				chat: [{ text: powerToEnact[1] }]
+				chat: [
+					{ text: 'A ' },
+					{
+						text: team === 'liberal' ? 'liberal' : 'fascist',
+						type: team === 'liberal' ? 'liberal' : 'fascist'
+					},
+					{
+						text: ` policy has been enacted. (${
+							team === 'liberal' ? game.trackState.liberalPolicyCount.toString() : game.trackState.fascistPolicyCount.toString()
+						}/${team === 'liberal' ? '5' : '6'})`
+					}
+				]
 			};
+			const addPreviousGovernmentStatus = () => {
+				game.publicPlayersState.forEach(player => {
+					if (player.previousGovernmentStatus) {
+						player.previousGovernmentStatus = '';
+					}
+				});
 
-			const { seatedPlayers } = game.private;
+				if (game.trackState.electionTrackerCount <= 2 && game.publicPlayersState.findIndex(player => player.governmentStatus === 'isChancellor') > -1) {
+					game.publicPlayersState[game.gameState.presidentIndex].previousGovernmentStatus = 'wasPresident';
+					game.publicPlayersState[game.publicPlayersState.findIndex(player => player.governmentStatus === 'isChancellor')].previousGovernmentStatus =
+						'wasChancellor';
+				}
+			};
+			const powerToEnact =
+				team === 'fascist'
+					? game.customGameSettings.enabled
+						? powerMapping[game.customGameSettings.powers[game.trackState.fascistPolicyCount - 1]]
+						: presidentPowers[game.general.type][game.trackState.fascistPolicyCount - 1]
+					: null;
+
+			game.trackState.enactedPolicies[index].position =
+				team === 'liberal' ? `liberal${game.trackState.liberalPolicyCount}` : `fascist${game.trackState.fascistPolicyCount}`;
 
 			if (!game.general.disableGamechat) {
-				seatedPlayers.forEach(player => {
+				game.private.seatedPlayers.forEach(player => {
 					player.gameChats.push(chat);
 				});
 
 				game.private.unSeatedGameChats.push(chat);
 			}
-			powerToEnact[0](game);
-			addPreviousGovernmentStatus();
 
-			if (game.general.timedMode) {
-				const { presidentIndex } = game.gameState;
+			if (game.trackState.liberalPolicyCount === 5 || game.trackState.fascistPolicyCount === 6) {
+				game.publicPlayersState.forEach((player, i) => {
+					player.cardStatus.cardFront = 'secretrole';
+					player.cardStatus.cardBack = game.private.seatedPlayers[i].role;
+					player.cardStatus.cardDisplayed = true;
+					player.cardStatus.isFlipped = false;
+				});
 
-				game.gameState.timedModeEnabled = true;
-				game.private.timerId = setTimeout(() => {
-					if (game.gameState.timedModeEnabled) {
-						const president = seatedPlayers[presidentIndex];
-						let list = seatedPlayers.filter((player, i) => i !== presidentIndex && !seatedPlayers[i].isDead);
-
-						game.gameState.timedModeEnabled = false;
-
-						switch (powerToEnact[1]) {
-							case 'The president must examine the top 3 policies.':
-								selectPolicies({ user: president.userName }, game);
-								break;
-							case 'The president must select a player for execution.':
-								if (president.role.cardName === 'fascist') {
-									list = list.filter(player => player.role.cardName !== 'hitler');
-								}
-								selectPlayerToExecute({ user: president.userName }, game, { playerIndex: seatedPlayers.indexOf(_.shuffle(list)[0]) });
-								break;
-							case 'The president must investigate the party membership of another player.':
-								selectPartyMembershipInvestigate({ user: president.userName }, game, { playerIndex: seatedPlayers.indexOf(_.shuffle(list)[0]) });
-								break;
-							case 'The president must select a player for a special election.':
-								selectSpecialElection({ user: president.userName }, game, { playerIndex: seatedPlayers.indexOf(_.shuffle(list)[0]) });
-								break;
-						}
-					}
-				}, process.env.DEVTIMEDDELAY ? process.env.DEVTIMEDDELAY : game.general.timedMode * 1000);
 				sendInProgressGameUpdate(game);
-			}
-		} else {
-			sendInProgressGameUpdate(game);
-			addPreviousGovernmentStatus();
-			startElection(game);
-		}
 
-		game.trackState.electionTrackerCount = 0;
-	}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 1000 : 4000);
+				game.gameState.audioCue = game.trackState.liberalPolicyCount === 5 ? 'liberalsWin' : 'fascistsWin';
+				setTimeout(
+					() => {
+						game.publicPlayersState.forEach((player, i) => {
+							player.cardStatus.isFlipped = true;
+						});
+						game.gameState.audioCue = '';
+						if (process.env.NODE_ENV === 'development') {
+							completeGame(game, game.trackState.liberalPolicyCount === 1 ? 'liberal' : 'fascist');
+						} else {
+							completeGame(game, game.trackState.liberalPolicyCount === 5 ? 'liberal' : 'fascist');
+						}
+					},
+					process.env.NODE_ENV === 'development' ? 100 : 2000
+				);
+			} else if (powerToEnact && game.trackState.electionTrackerCount <= 2) {
+				const chat = {
+					timestamp: new Date(),
+					gameChat: true,
+					chat: [{ text: powerToEnact[1] }]
+				};
+
+				const { seatedPlayers } = game.private;
+
+				if (!game.general.disableGamechat) {
+					seatedPlayers.forEach(player => {
+						player.gameChats.push(chat);
+					});
+
+					game.private.unSeatedGameChats.push(chat);
+				}
+				powerToEnact[0](game);
+				addPreviousGovernmentStatus();
+
+				if (game.general.timedMode) {
+					const { presidentIndex } = game.gameState;
+
+					game.gameState.timedModeEnabled = true;
+					game.private.timerId = setTimeout(
+						() => {
+							if (game.gameState.timedModeEnabled) {
+								const president = seatedPlayers[presidentIndex];
+								let list = seatedPlayers.filter((player, i) => i !== presidentIndex && !seatedPlayers[i].isDead);
+
+								game.gameState.timedModeEnabled = false;
+
+								switch (powerToEnact[1]) {
+									case 'The president must examine the top 3 policies.':
+										selectPolicies({ user: president.userName }, game);
+										break;
+									case 'The president must select a player for execution.':
+										if (president.role.cardName === 'fascist') {
+											list = list.filter(player => player.role.cardName !== 'hitler');
+										}
+										selectPlayerToExecute({ user: president.userName }, game, { playerIndex: seatedPlayers.indexOf(_.shuffle(list)[0]) });
+										break;
+									case 'The president must investigate the party membership of another player.':
+										selectPartyMembershipInvestigate({ user: president.userName }, game, { playerIndex: seatedPlayers.indexOf(_.shuffle(list)[0]) });
+										break;
+									case 'The president must select a player for a special election.':
+										selectSpecialElection({ user: president.userName }, game, { playerIndex: seatedPlayers.indexOf(_.shuffle(list)[0]) });
+										break;
+								}
+							}
+						},
+						process.env.DEVTIMEDDELAY ? process.env.DEVTIMEDDELAY : game.general.timedMode * 1000
+					);
+					sendInProgressGameUpdate(game);
+				}
+			} else {
+				sendInProgressGameUpdate(game);
+				addPreviousGovernmentStatus();
+				startElection(game);
+			}
+
+			game.trackState.electionTrackerCount = 0;
+		},
+		process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 1000 : 4000
+	);
 };
 
 /**
@@ -299,7 +314,7 @@ const selectPresidentVoteOnVeto = (passport, game, data) => {
 		}
 
 		publicPresident.cardStatus = {
-			cardDisplayed: true,
+			cardDisplayed: false,
 			cardFront: 'ballot',
 			cardBack: {
 				cardName: data.vote ? 'ja' : 'nein'
@@ -308,90 +323,99 @@ const selectPresidentVoteOnVeto = (passport, game, data) => {
 
 		sendInProgressGameUpdate(game);
 
-		setTimeout(() => {
-			const chat = {
-				timestamp: new Date(),
-				gameChat: true,
-				chat: [
-					{ text: 'President ' },
-					{
-						text: game.general.blindMode
-							? `{${game.private.seatedPlayers.indexOf(president) + 1}}`
-							: `${passport.user} {${game.private.seatedPlayers.indexOf(president) + 1}}`,
-						type: 'player'
-					},
-					{
-						text: data.vote ? ' has voted to veto this election.' : ' has voted not to veto this election.'
-					}
-				]
-			};
-
-			if (!game.general.disableGamechat) {
-				game.private.seatedPlayers.forEach(player => {
-					player.gameChats.push(chat);
-				});
-				game.private.unSeatedGameChats.push(chat);
-			}
-
-			publicPresident.cardStatus.isFlipped = true;
-
-			sendInProgressGameUpdate(game);
-
-			if (data.vote) {
+		setTimeout(
+			() => {
 				const chat = {
-					gameChat: true,
 					timestamp: new Date(),
+					gameChat: true,
 					chat: [
+						{ text: 'President ' },
 						{
-							text: 'The President and Chancellor have voted to veto this election and the election tracker moves forward.'
+							text: game.general.blindMode
+								? `{${game.private.seatedPlayers.indexOf(president) + 1}}`
+								: `${passport.user} {${game.private.seatedPlayers.indexOf(president) + 1}}`,
+							type: 'player'
+						},
+						{
+							text: data.vote ? ' has voted on whether to veto this election.' : ' has voted on whether to veto this election.'
 						}
 					]
 				};
-
-				game.gameState.pendingChancellorIndex = null;
-				game.private.lock.selectChancellorPolicy = game.private.lock.selectPresidentVoteOnVeto = game.private.lock.selectChancellorVoteOnVeto = false;
-				game.trackState.electionTrackerCount++;
 
 				if (!game.general.disableGamechat) {
 					game.private.seatedPlayers.forEach(player => {
 						player.gameChats.push(chat);
 					});
-
 					game.private.unSeatedGameChats.push(chat);
 				}
-				game.gameState.audioCue = 'passedVeto';
-				setTimeout(() => {
-					game.gameState.audioCue = '';
-					president.cardFlingerState = [];
-					if (game.trackState.electionTrackerCount >= 3) {
-						if (!game.gameState.undrawnPolicyCount) {
-							shufflePolicies(game);
-						}
 
-						enactPolicy(game, game.private.policies.shift());
-						game.gameState.undrawnPolicyCount--;
-						if (game.gameState.undrawnPolicyCount < 3) {
-							shufflePolicies(game);
-						}
-					} else {
-						startElection(game);
-					}
-				}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 1000 : 3000);
-			} else {
-				game.gameState.audioCue = 'failedVeto';
+				publicPresident.cardStatus.isFlipped = true;
+
 				sendInProgressGameUpdate(game);
-				setTimeout(() => {
-					game.gameState.audioCue = '';
-					publicPresident.cardStatus.cardDisplayed = false;
-					publicChancellor.cardStatus.cardDisplayed = false;
-					president.cardFlingerState = [];
-					enactPolicy(game, game.private.currentElectionPolicies[0]);
-					setTimeout(() => {
-						publicChancellor.cardStatus.isFlipped = publicPresident.cardStatus.isFlipped = false;
-					}, 1000);
-				}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 1000 : 2000);
-			}
-		}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 2000);
+
+				if (data.vote == true && ChancellorRejectsVeto == false) {
+					const chat = {
+						gameChat: true,
+						timestamp: new Date(),
+						chat: [
+							{
+								text: 'The Veto succeeds: the President and Chancellor have both voted to veto this election and the election tracker moves forward.'
+							}
+						]
+					};
+
+					game.gameState.pendingChancellorIndex = null;
+					game.private.lock.selectChancellorPolicy = game.private.lock.selectPresidentVoteOnVeto = game.private.lock.selectChancellorVoteOnVeto = false;
+					game.trackState.electionTrackerCount++;
+
+					if (!game.general.disableGamechat) {
+						game.private.seatedPlayers.forEach(player => {
+							player.gameChats.push(chat);
+						});
+
+						game.private.unSeatedGameChats.push(chat);
+					}
+					game.gameState.audioCue = 'passedVeto';
+					setTimeout(
+						() => {
+							game.gameState.audioCue = '';
+							president.cardFlingerState = [];
+							if (game.trackState.electionTrackerCount >= 3) {
+								if (!game.gameState.undrawnPolicyCount) {
+									shufflePolicies(game);
+								}
+
+								enactPolicy(game, game.private.policies.shift());
+								game.gameState.undrawnPolicyCount--;
+								if (game.gameState.undrawnPolicyCount < 3) {
+									shufflePolicies(game);
+								}
+							} else {
+								startElection(game);
+							}
+						},
+						process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 1000 : 3000
+					);
+				} else {
+					game.gameState.audioCue = 'failedVeto';
+					sendInProgressGameUpdate(game);
+					setTimeout(
+						() => {
+							game.gameState.audioCue = '';
+							publicPresident.cardStatus.cardDisplayed = false;
+							publicChancellor.cardStatus.cardDisplayed = false;
+							president.cardFlingerState = [];
+							enactPolicy(game, game.private.currentElectionPolicies[0]);
+							setTimeout(() => {
+								publicChancellor.cardStatus.isFlipped = publicPresident.cardStatus.isFlipped = false;
+							}, 1000);
+						},
+						process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 1000 : 2000
+					);
+				}
+			},
+			process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 2000
+		);
 	}
 };
 
@@ -442,7 +466,7 @@ const selectChancellorVoteOnVeto = (passport, game, data) => {
 		}
 
 		publicChancellor.cardStatus = {
-			cardDisplayed: true,
+			cardDisplayed: false,
 			cardFront: 'ballot',
 			cardBack: {
 				cardName: data.vote ? 'ja' : 'nein'
@@ -451,104 +475,107 @@ const selectChancellorVoteOnVeto = (passport, game, data) => {
 
 		sendInProgressGameUpdate(game);
 
-		setTimeout(() => {
-			const chat = {
-				timestamp: new Date(),
-				gameChat: true,
-				chat: [
-					{ text: 'Chancellor ' },
-					{
-						text: game.general.blindMode ? `{${chancellorIndex + 1}}` : `${passport.user} {${chancellorIndex + 1}}`,
-						type: 'player'
-					},
-					{
-						text: data.vote ? ' has voted to veto this election.' : ' has voted not to veto this election.'
-					}
-				]
-			};
-
-			if (!game.general.disableGamechat) {
-				game.private.seatedPlayers.forEach(player => {
-					player.gameChats.push(chat);
-				});
-
-				game.private.unSeatedGameChats.push(chat);
-			}
-
-			publicChancellor.cardStatus.isFlipped = true;
-			sendInProgressGameUpdate(game);
-
-			if (data.vote) {
-				president.cardFlingerState = [
-					{
-						position: 'middle-left',
-						notificationStatus: '',
-						action: 'active',
-						cardStatus: {
-							isFlipped: false,
-							cardFront: 'ballot',
-							cardBack: 'ja'
+		setTimeout(
+			() => {
+				const chat = {
+					timestamp: new Date(),
+					gameChat: true,
+					chat: [
+						{ text: 'Chancellor ' },
+						{
+							text: game.general.blindMode ? `{${chancellorIndex + 1}}` : `${passport.user} {${chancellorIndex + 1}}`,
+							type: 'player'
+						},
+						{
+							text: data.vote ? ' has voted on whether to veto this election.' : ' has voted on whether to veto this election.'
 						}
-					},
-					{
-						position: 'middle-right',
-						action: 'active',
-						notificationStatus: '',
-						cardStatus: {
-							isFlipped: false,
-							cardFront: 'ballot',
-							cardBack: 'nein'
-						}
-					}
-				];
+					]
+				};
 
 				if (!game.general.disableGamechat) {
-					president.gameChats.push({
-						gameChat: true,
-						timestamp: new Date(),
-						chat: [
-							{
-								text:
-									'You must vote whether or not to veto these policies.  Select Ja to veto the policies you passed to the Chancellor or select Nein to enact the policy the Chancellor has chosen in secret.'
-							}
-						]
+					game.private.seatedPlayers.forEach(player => {
+						player.gameChats.push(chat);
 					});
+
+					game.private.unSeatedGameChats.push(chat);
 				}
 
-				game.general.status = 'President to vote on policy veto.';
+				publicChancellor.cardStatus.isFlipped = true;
 				sendInProgressGameUpdate(game);
-				setTimeout(() => {
-					president.cardFlingerState[0].cardStatus.isFlipped = president.cardFlingerState[1].cardStatus.isFlipped = true;
-					president.cardFlingerState[0].notificationStatus = president.cardFlingerState[1].notificationStatus = 'notification';
-					chancellor.cardFlingerState = [];
-					game.publicPlayersState[game.gameState.presidentIndex].isLoader = true;
-					game.gameState.phase = 'presidentVoteOnVeto';
-					sendInProgressGameUpdate(game);
 
-					if (game.general.timedMode) {
-						game.gameState.timedModeEnabled = true;
-						game.private.timerId = setTimeout(() => {
-							if (game.gameState.timedModeEnabled) {
-								game.gameState.timedModeEnabled = false;
-								selectPresidentVoteOnVeto({ user: president.userName }, game, { vote: Boolean(Math.floor(Math.random() * 2)) });
+				if (data.vote == false) {
+					ChancellorRejectsVeto = true;
+				}
+				if (data.vote == true) {
+					ChancellorRejectsVeto = false;
+				}
+				if (1) {
+					president.cardFlingerState = [
+						{
+							position: 'middle-left',
+							notificationStatus: '',
+							action: 'active',
+							cardStatus: {
+								isFlipped: false,
+								cardFront: 'ballot',
+								cardBack: 'ja'
 							}
-						}, process.env.DEVTIMEDDELAY ? process.env.DEVTIMEDDELAY : game.general.timedMode * 1000);
+						},
+						{
+							position: 'middle-right',
+							action: 'active',
+							notificationStatus: '',
+							cardStatus: {
+								isFlipped: false,
+								cardFront: 'ballot',
+								cardBack: 'nein'
+							}
+						}
+					];
+
+					if (!game.general.disableGamechat) {
+						president.gameChats.push({
+							gameChat: true,
+							timestamp: new Date(),
+							chat: [
+								{
+									text:
+										'You must vote whether or not to veto these policies.  Select Ja to veto the policies you passed to the Chancellor or select Nein to enact the policy the Chancellor has chosen in secret.'
+								}
+							]
+						});
 					}
-				}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 1000);
-			} else {
-				game.gameState.audioCue = 'failedVeto';
-				sendInProgressGameUpdate(game);
-				setTimeout(() => {
-					game.gameState.audioCue = '';
-					publicChancellor.cardStatus.cardDisplayed = false;
-					chancellor.cardFlingerState = [];
-					setTimeout(() => {
-						publicChancellor.cardStatus.isFlipped = false;
-					}, 1000);
-					enactPolicy(game, game.private.currentElectionPolicies[0]);
-				}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 2000);
-			}
-		}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 2000);
+
+					game.general.status = 'President to vote on policy veto.';
+					sendInProgressGameUpdate(game);
+					setTimeout(
+						() => {
+							president.cardFlingerState[0].cardStatus.isFlipped = president.cardFlingerState[1].cardStatus.isFlipped = true;
+							president.cardFlingerState[0].notificationStatus = president.cardFlingerState[1].notificationStatus = 'notification';
+							chancellor.cardFlingerState = [];
+							game.publicPlayersState[game.gameState.presidentIndex].isLoader = true;
+							game.gameState.phase = 'presidentVoteOnVeto';
+							sendInProgressGameUpdate(game);
+
+							if (game.general.timedMode) {
+								game.gameState.timedModeEnabled = true;
+								game.private.timerId = setTimeout(
+									() => {
+										if (game.gameState.timedModeEnabled) {
+											game.gameState.timedModeEnabled = false;
+											selectPresidentVoteOnVeto({ user: president.userName }, game, { vote: Boolean(Math.floor(Math.random() * 2)) });
+										}
+									},
+									process.env.DEVTIMEDDELAY ? process.env.DEVTIMEDDELAY : game.general.timedMode * 1000
+								);
+							}
+						},
+						process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 1000
+					);
+				}
+			},
+			process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 2000
+		);
 	}
 };
 
@@ -664,75 +691,88 @@ const selectChancellorPolicy = (passport, game, data, wasTimer) => {
 			game.general.status = 'Chancellor to vote on policy veto.';
 			sendInProgressGameUpdate(game);
 
-			setTimeout(() => {
-				const chat = {
-					gameChat: true,
-					timestamp: new Date(),
-					chat: [
-						{
-							text: 'You must vote whether or not to veto these policies.  Select Ja to veto the your chosen policy or select Nein to enact your chosen policy.'
-						}
-					]
-				};
-
-				game.publicPlayersState[chancellorIndex].isLoader = true;
-
-				chancellor.cardFlingerState = [
-					{
-						position: 'middle-left',
-						notificationStatus: '',
-						action: 'active',
-						cardStatus: {
-							isFlipped: false,
-							cardFront: 'ballot',
-							cardBack: 'ja'
-						}
-					},
-					{
-						position: 'middle-right',
-						action: 'active',
-						notificationStatus: '',
-						cardStatus: {
-							isFlipped: false,
-							cardFront: 'ballot',
-							cardBack: 'nein'
-						}
-					}
-				];
-
-				if (!game.general.disableGamechat) {
-					chancellor.gameChats.push(chat);
-				}
-
-				sendInProgressGameUpdate(game);
-
-				setTimeout(() => {
-					chancellor.cardFlingerState[0].cardStatus.isFlipped = chancellor.cardFlingerState[1].cardStatus.isFlipped = true;
-					chancellor.cardFlingerState[0].notificationStatus = chancellor.cardFlingerState[1].notificationStatus = 'notification';
-					game.gameState.phase = 'chancellorVoteOnVeto';
-
-					if (game.general.timedMode) {
-						game.gameState.timedModeEnabled = true; // (passport, game, data)
-						game.private.timerId = setTimeout(() => {
-							if (game.gameState.timedModeEnabled) {
-								game.gameState.timedModeEnabled = false;
-
-								selectChancellorVoteOnVeto({ user: chancellor.userName }, game, { vote: Boolean(Math.floor(Math.random() * 2)) });
+			setTimeout(
+				() => {
+					const chat = {
+						gameChat: true,
+						timestamp: new Date(),
+						chat: [
+							{
+								text:
+									'You must vote whether or not to veto these policies.  Select Ja to veto the your chosen policy or select Nein to enact your chosen policy.'
 							}
-						}, process.env.DEVTIMEDDELAY ? process.env.DEVTIMEDDELAY : game.general.timedMode * 1000);
+						]
+					};
+
+					game.publicPlayersState[chancellorIndex].isLoader = true;
+
+					chancellor.cardFlingerState = [
+						{
+							position: 'middle-left',
+							notificationStatus: '',
+							action: 'active',
+							cardStatus: {
+								isFlipped: false,
+								cardFront: 'ballot',
+								cardBack: 'ja'
+							}
+						},
+						{
+							position: 'middle-right',
+							action: 'active',
+							notificationStatus: '',
+							cardStatus: {
+								isFlipped: false,
+								cardFront: 'ballot',
+								cardBack: 'nein'
+							}
+						}
+					];
+
+					if (!game.general.disableGamechat) {
+						chancellor.gameChats.push(chat);
 					}
 
 					sendInProgressGameUpdate(game);
-				}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 1000);
-			}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 1000 : 2000);
+
+					setTimeout(
+						() => {
+							chancellor.cardFlingerState[0].cardStatus.isFlipped = chancellor.cardFlingerState[1].cardStatus.isFlipped = true;
+							chancellor.cardFlingerState[0].notificationStatus = chancellor.cardFlingerState[1].notificationStatus = 'notification';
+							game.gameState.phase = 'chancellorVoteOnVeto';
+
+							if (game.general.timedMode) {
+								game.gameState.timedModeEnabled = true; // (passport, game, data)
+								game.private.timerId = setTimeout(
+									() => {
+										if (game.gameState.timedModeEnabled) {
+											game.gameState.timedModeEnabled = false;
+
+											selectChancellorVoteOnVeto({ user: chancellor.userName }, game, { vote: Boolean(Math.floor(Math.random() * 2)) });
+										}
+									},
+									process.env.DEVTIMEDDELAY ? process.env.DEVTIMEDDELAY : game.general.timedMode * 1000
+								);
+							}
+
+							sendInProgressGameUpdate(game);
+						},
+						process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 1000
+					);
+				},
+				process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 1000 : 2000
+			);
 		} else {
 			game.private.currentElectionPolicies = [];
 			game.gameState.phase = 'enactPolicy';
 			sendInProgressGameUpdate(game);
-			setTimeout(() => {
-				chancellor.cardFlingerState = [];
-				enactPolicy(game, enactedPolicy);
-			}, experiencedMode ? 200 : 2000);
+			setTimeout(
+				() => {
+					chancellor.cardFlingerState = [];
+					enactPolicy(game, enactedPolicy);
+				},
+				experiencedMode ? 200 : 2000
+			);
 		}
 		if (experiencedMode) {
 			president.playersState[presidentIndex].claim = 'wasPresident';
@@ -955,28 +995,34 @@ const selectPresidentPolicy = (passport, game, data, wasTimer) => {
 
 		sendInProgressGameUpdate(game);
 
-		setTimeout(() => {
-			president.cardFlingerState = [];
-			chancellor.cardFlingerState.forEach(cardFlinger => {
-				cardFlinger.cardStatus.isFlipped = true;
-			});
-			chancellor.cardFlingerState.forEach(cardFlinger => {
-				cardFlinger.notificationStatus = 'notification';
-			});
+		setTimeout(
+			() => {
+				president.cardFlingerState = [];
+				chancellor.cardFlingerState.forEach(cardFlinger => {
+					cardFlinger.cardStatus.isFlipped = true;
+				});
+				chancellor.cardFlingerState.forEach(cardFlinger => {
+					cardFlinger.notificationStatus = 'notification';
+				});
 
-			if (game.general.timedMode) {
-				game.gameState.timedModeEnabled = true;
-				game.private.timerId = setTimeout(() => {
-					if (game.gameState.timedModeEnabled) {
-						const isRightPolicy = Boolean(Math.floor(Math.random() * 2));
+				if (game.general.timedMode) {
+					game.gameState.timedModeEnabled = true;
+					game.private.timerId = setTimeout(
+						() => {
+							if (game.gameState.timedModeEnabled) {
+								const isRightPolicy = Boolean(Math.floor(Math.random() * 2));
 
-						selectChancellorPolicy({ user: chancellor.userName }, game, { selection: isRightPolicy ? 3 : 1 }, true);
-					}
-				}, process.env.DEVTIMEDDELAY ? process.env.DEVTIMEDDELAY : game.general.timedMode * 1000);
-			}
+								selectChancellorPolicy({ user: chancellor.userName }, game, { selection: isRightPolicy ? 3 : 1 }, true);
+							}
+						},
+						process.env.DEVTIMEDDELAY ? process.env.DEVTIMEDDELAY : game.general.timedMode * 1000
+					);
+				}
 
-			sendInProgressGameUpdate(game);
-		}, game.general.experiencedMode ? 200 : 2000);
+				sendInProgressGameUpdate(game);
+			},
+			game.general.experiencedMode ? 200 : 2000
+		);
 	}
 };
 
@@ -1109,28 +1155,34 @@ module.exports.selectVoting = (passport, game, data) => {
 			gameState.undrawnPolicyCount--;
 			sendInProgressGameUpdate(game);
 		}, 400);
-		setTimeout(() => {
-			seatedPlayers[presidentIndex].cardFlingerState[0].cardStatus.isFlipped = seatedPlayers[
-				presidentIndex
-			].cardFlingerState[1].cardStatus.isFlipped = seatedPlayers[presidentIndex].cardFlingerState[2].cardStatus.isFlipped = true;
-			seatedPlayers[presidentIndex].cardFlingerState[0].notificationStatus = seatedPlayers[
-				presidentIndex
-			].cardFlingerState[1].notificationStatus = seatedPlayers[presidentIndex].cardFlingerState[2].notificationStatus = 'notification';
-			gameState.phase = 'presidentSelectingPolicy';
+		setTimeout(
+			() => {
+				seatedPlayers[presidentIndex].cardFlingerState[0].cardStatus.isFlipped = seatedPlayers[
+					presidentIndex
+				].cardFlingerState[1].cardStatus.isFlipped = seatedPlayers[presidentIndex].cardFlingerState[2].cardStatus.isFlipped = true;
+				seatedPlayers[presidentIndex].cardFlingerState[0].notificationStatus = seatedPlayers[
+					presidentIndex
+				].cardFlingerState[1].notificationStatus = seatedPlayers[presidentIndex].cardFlingerState[2].notificationStatus = 'notification';
+				gameState.phase = 'presidentSelectingPolicy';
 
-			game.gameState.previousElectedGovernment = [presidentIndex, chancellorIndex];
+				game.gameState.previousElectedGovernment = [presidentIndex, chancellorIndex];
 
-			if (game.general.timedMode) {
-				game.gameState.timedModeEnabled = true;
-				game.private.timerId = setTimeout(() => {
-					if (game.gameState.timedModeEnabled) {
-						game.gameState.timedModeEnabled = false;
-						selectPresidentPolicy({ user: seatedPlayers[presidentIndex].userName }, game, { selection: Math.floor(Math.random() * 3) }, true);
-					}
-				}, process.env.DEVTIMEDDELAY ? process.env.DEVTIMEDDELAY : game.general.timedMode * 1000);
-			}
-			sendInProgressGameUpdate(game);
-		}, experiencedMode ? 200 : 600);
+				if (game.general.timedMode) {
+					game.gameState.timedModeEnabled = true;
+					game.private.timerId = setTimeout(
+						() => {
+							if (game.gameState.timedModeEnabled) {
+								game.gameState.timedModeEnabled = false;
+								selectPresidentPolicy({ user: seatedPlayers[presidentIndex].userName }, game, { selection: Math.floor(Math.random() * 3) }, true);
+							}
+						},
+						process.env.DEVTIMEDDELAY ? process.env.DEVTIMEDDELAY : game.general.timedMode * 1000
+					);
+				}
+				sendInProgressGameUpdate(game);
+			},
+			experiencedMode ? 200 : 600
+		);
 	};
 	const failedElection = () => {
 		game.trackState.electionTrackerCount++;
@@ -1161,27 +1213,36 @@ module.exports.selectVoting = (passport, game, data) => {
 			}
 
 			game.gameState.undrawnPolicyCount--;
-			setTimeout(() => {
-				enactPolicy(game, game.private.policies.shift());
-			}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 2000);
+			setTimeout(
+				() => {
+					enactPolicy(game, game.private.policies.shift());
+				},
+				process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 2000
+			);
 		} else {
 			if (game.general.timedMode) {
 				game.gameState.timedModeEnabled = true;
-				game.private.timerId = setTimeout(() => {
-					if (game.gameState.timedModeEnabled && game.gameState.phase === 'selectingChancellor') {
-						const chancellorIndex = _.shuffle(game.gameState.clickActionInfo[1])[0];
+				game.private.timerId = setTimeout(
+					() => {
+						if (game.gameState.timedModeEnabled && game.gameState.phase === 'selectingChancellor') {
+							const chancellorIndex = _.shuffle(game.gameState.clickActionInfo[1])[0];
 
-						game.gameState.pendingChancellorIndex = null;
-						game.gameState.timedModeEnabled = false;
+							game.gameState.pendingChancellorIndex = null;
+							game.gameState.timedModeEnabled = false;
 
-						selectChancellor(null, { user: game.private.seatedPlayers[game.gameState.presidentIndex].userName }, game, { chancellorIndex: chancellorIndex });
-					}
-				}, process.env.DEVTIMEDDELAY ? process.env.DEVTIMEDDELAY : game.general.timedMode * 1000);
+							selectChancellor(null, { user: game.private.seatedPlayers[game.gameState.presidentIndex].userName }, game, { chancellorIndex: chancellorIndex });
+						}
+					},
+					process.env.DEVTIMEDDELAY ? process.env.DEVTIMEDDELAY : game.general.timedMode * 1000
+				);
 			}
 
-			setTimeout(() => {
-				module.exports.startElection(game);
-			}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 2000);
+			setTimeout(
+				() => {
+					module.exports.startElection(game);
+				},
+				process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 2000
+			);
 		}
 	};
 	const flipBallotCards = () => {
@@ -1205,113 +1266,125 @@ module.exports.selectVoting = (passport, game, data) => {
 
 		sendInProgressGameUpdate(game, true);
 
-		setTimeout(() => {
-			const chat = {
-				timestamp: new Date(),
-				gameChat: true
-			};
+		setTimeout(
+			() => {
+				const chat = {
+					timestamp: new Date(),
+					gameChat: true
+				};
 
-			game.publicPlayersState.forEach((play, i) => {
-				play.cardStatus.cardDisplayed = false;
-			});
-
-			setTimeout(() => {
 				game.publicPlayersState.forEach((play, i) => {
-					play.cardStatus.isFlipped = false;
+					play.cardStatus.cardDisplayed = false;
 				});
-				sendInProgressGameUpdate(game);
-			}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 2000);
 
-			if (seatedPlayers.filter(play => play.voteStatus.didVoteYes && !play.isDead).length / game.general.livingPlayerCount > 0.5) {
-				const chancellorIndex = game.gameState.pendingChancellorIndex;
-				const { presidentIndex } = game.gameState;
-
-				game.publicPlayersState[presidentIndex].governmentStatus = 'isPresident';
-
-				game.publicPlayersState[chancellorIndex].governmentStatus = 'isChancellor';
-				chat.chat = [{ text: 'The election passes.' }];
-
-				if (!experiencedMode && !game.general.disableGamechat) {
-					seatedPlayers.forEach(player => {
-						player.gameChats.push(chat);
-					});
-
-					game.private.unSeatedGameChats.push(chat);
-				}
-
-				if (
-					game.trackState.fascistPolicyCount >= game.customGameSettings.hitlerZone &&
-					game.private.seatedPlayers[chancellorIndex].role.cardName === 'hitler'
-				) {
-					const getNumberText = val => {
-						if (val == 1) return '1st';
-						if (val == 2) return '2nd';
-						if (val == 3) return '3rd';
-						return `${val}th`;
-					};
-					const chat = {
-						timestamp: new Date(),
-						gameChat: true,
-						chat: [
-							{
-								text: 'Hitler',
-								type: 'hitler'
-							},
-							{
-								text: ` has been elected chancellor after the ${getNumberText(game.customGameSettings.hitlerZone)} fascist policy has been enacted.`
-							}
-						]
-					};
-
-					setTimeout(() => {
-						game.publicPlayersState.forEach((player, i) => {
-							player.cardStatus.cardFront = 'secretrole';
-							player.cardStatus.cardDisplayed = true;
-							player.cardStatus.cardBack = seatedPlayers[i].role;
+				setTimeout(
+					() => {
+						game.publicPlayersState.forEach((play, i) => {
+							play.cardStatus.isFlipped = false;
 						});
-
-						if (!game.general.disableGamechat) {
-							seatedPlayers.forEach(player => {
-								player.gameChats.push(chat);
-							});
-
-							game.gameState.audioCue = 'fascistsWinHitlerElected';
-							game.private.unSeatedGameChats.push(chat);
-						}
 						sendInProgressGameUpdate(game);
-					}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 1000 : 3000);
+					},
+					process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 500 : 2000
+				);
 
-					setTimeout(() => {
-						game.gameState.audioCue = '';
-						game.publicPlayersState.forEach(player => {
-							player.cardStatus.isFlipped = true;
+				if (seatedPlayers.filter(play => play.voteStatus.didVoteYes && !play.isDead).length / game.general.livingPlayerCount > 0.5) {
+					const chancellorIndex = game.gameState.pendingChancellorIndex;
+					const { presidentIndex } = game.gameState;
+
+					game.publicPlayersState[presidentIndex].governmentStatus = 'isPresident';
+
+					game.publicPlayersState[chancellorIndex].governmentStatus = 'isChancellor';
+					chat.chat = [{ text: 'The election passes.' }];
+
+					if (!experiencedMode && !game.general.disableGamechat) {
+						seatedPlayers.forEach(player => {
+							player.gameChats.push(chat);
 						});
-						completeGame(game, 'fascist');
-					}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 2000 : 4000);
+
+						game.private.unSeatedGameChats.push(chat);
+					}
+
+					if (
+						game.trackState.fascistPolicyCount >= game.customGameSettings.hitlerZone &&
+						game.private.seatedPlayers[chancellorIndex].role.cardName === 'hitler'
+					) {
+						const getNumberText = val => {
+							if (val == 1) return '1st';
+							if (val == 2) return '2nd';
+							if (val == 3) return '3rd';
+							return `${val}th`;
+						};
+						const chat = {
+							timestamp: new Date(),
+							gameChat: true,
+							chat: [
+								{
+									text: 'Hitler',
+									type: 'hitler'
+								},
+								{
+									text: ` has been elected chancellor after the ${getNumberText(game.customGameSettings.hitlerZone)} fascist policy has been enacted.`
+								}
+							]
+						};
+
+						setTimeout(
+							() => {
+								game.publicPlayersState.forEach((player, i) => {
+									player.cardStatus.cardFront = 'secretrole';
+									player.cardStatus.cardDisplayed = true;
+									player.cardStatus.cardBack = seatedPlayers[i].role;
+								});
+
+								if (!game.general.disableGamechat) {
+									seatedPlayers.forEach(player => {
+										player.gameChats.push(chat);
+									});
+
+									game.gameState.audioCue = 'fascistsWinHitlerElected';
+									game.private.unSeatedGameChats.push(chat);
+								}
+								sendInProgressGameUpdate(game);
+							},
+							process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 1000 : 3000
+						);
+
+						setTimeout(
+							() => {
+								game.gameState.audioCue = '';
+								game.publicPlayersState.forEach(player => {
+									player.cardStatus.isFlipped = true;
+								});
+								completeGame(game, 'fascist');
+							},
+							process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 2000 : 4000
+						);
+					} else {
+						passedElection();
+					}
 				} else {
-					passedElection();
+					if (!game.general.disableGamechat) {
+						chat.chat = [
+							{
+								text: 'The election fails and the election tracker moves forward.'
+							}
+						];
+
+						seatedPlayers.forEach(player => {
+							player.gameChats.push(chat);
+						});
+
+						game.private.unSeatedGameChats.push(chat);
+						game.gameState.pendingChancellorIndex = null;
+					}
+
+					failedElection();
 				}
-			} else {
-				if (!game.general.disableGamechat) {
-					chat.chat = [
-						{
-							text: 'The election fails and the election tracker moves forward.'
-						}
-					];
 
-					seatedPlayers.forEach(player => {
-						player.gameChats.push(chat);
-					});
-
-					game.private.unSeatedGameChats.push(chat);
-					game.gameState.pendingChancellorIndex = null;
-				}
-
-				failedElection();
-			}
-
-			sendInProgressGameUpdate(game);
-		}, process.env.NODE_ENV === 'development' ? 2100 : isConsensus ? 1500 : 6000);
+				sendInProgressGameUpdate(game);
+			},
+			process.env.NODE_ENV === 'development' ? 2100 : isConsensus ? 1500 : 6000
+		);
 	};
 
 	if (game.general.isTourny && game.general.tournyInfo.isCancelled) {
@@ -1387,19 +1460,25 @@ module.exports.selectVoting = (passport, game, data) => {
 				}
 			});
 			sendInProgressGameUpdate(game, true);
-			setTimeout(() => {
-				seatedPlayers.forEach(player => {
-					player.cardFlingerState = [];
-					sendInProgressGameUpdate(game, true);
-				});
-			}, experiencedMode ? 200 : 2000);
-			setTimeout(() => {
-				if (game.general.timedMode && game.private.timerId) {
-					clearTimeout(game.private.timerId);
-					game.gameState.timedModeEnabled = game.private.timerId = null;
-				}
-				flipBallotCards();
-			}, process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 2500 : 3000);
+			setTimeout(
+				() => {
+					seatedPlayers.forEach(player => {
+						player.cardFlingerState = [];
+						sendInProgressGameUpdate(game, true);
+					});
+				},
+				experiencedMode ? 200 : 2000
+			);
+			setTimeout(
+				() => {
+					if (game.general.timedMode && game.private.timerId) {
+						clearTimeout(game.private.timerId);
+						game.gameState.timedModeEnabled = game.private.timerId = null;
+					}
+					flipBallotCards();
+				},
+				process.env.NODE_ENV === 'development' ? 100 : experiencedMode ? 2500 : 3000
+			);
 		}
 	}
 };

--- a/src/frontend-scripts/components/section-main/CardFlinger.jsx
+++ b/src/frontend-scripts/components/section-main/CardFlinger.jsx
@@ -120,6 +120,9 @@ class CardFlinger extends React.Component {
 				return (
 					<div className="help-message veto">
 						Would you like to <span>VETO</span> both of these policies?
+						<div className="secondary-message">
+							This vote is <span>SECRET</span>.
+						</div>
 					</div>
 				);
 			} else if (status === 'President to peek at policies.' && currentPlayerStatus === 'isPresident') {


### PR DESCRIPTION
This pull request fixes issue [#1061](https://github.com/cozuya/secret-hitler/issues/1061). The motivation (in short) is to allow fascists to play Reds in the veto zone without outing while still letting lib-lib governments veto RRRs. This is accomplished by anonymizing the veto process.

The change to election.js implements the fix.
The change to CardFlinger.jsx alters the prompt in the veto zone to tell the President and Chancellor that their choices to veto or not are secret.

I apologise for any bugs that I may have missed.

