### PR TITLE
Code Cleanup

### DIFF
--- a/routes/socket/ip-obfuscator-v6.js
+++ b/routes/socket/ip-obfuscator-v6.js
@@ -1,44 +1,27 @@
-let map;
-
-const block = [];
+const map = [];
 const avail = [];
-const convertToHex = val => {
-	let output = '';
-	for (let a = 0; a < 4; a++) {
-		let sub = val % 16;
-		val = Math.floor(val / 16);
-		if (sub === 10) sub = 'a';
-		if (sub === 11) sub = 'b';
-		if (sub === 12) sub = 'c';
-		if (sub === 13) sub = 'd';
-		if (sub === 14) sub = 'e';
-		if (sub === 15) sub = 'f';
-		output = sub + output;
-	}
-	return output;
-};
+const convertToHex = num => num.toString(16).padStart(4, '0');
+
 for (let a = 0; a < 16 * 16 * 16 * 16; a++) avail[a] = convertToHex(a);
 
-const doWork = () => {
-	let counter = 0;
-	while (avail.length > 0) {
-		const idx1 = Math.floor(Math.random() * avail.length);
-		const val1 = avail[idx1];
-		avail.splice(idx1, 1);
-		const idx2 = Math.floor(Math.random() * avail.length);
-		const val2 = avail[idx2];
-		avail.splice(idx2, 1);
-		block[val1] = val2;
-		block[val2] = val1;
-		counter++;
-		if (counter === 100) {
-			setTimeout(() => doWork(), 25);
-			return;
-		}
-	}
-	map = block;
-};
-doWork();
+// Taken from https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
+const shuffleArray = array => {
+	for (var i = array.length - 1; i > 0; i--) {
+		var j = Math.floor(Math.random() * (i + 1));
+		var temp = array[i];
+		array[i] = array[j];
+		array[j] = temp;
+    	}
+}
+shuffleArray(avail);
+
+for (let i = 0; i < avail.length; i += 2) {
+	const val1 = avail[i];
+	const val2 = avail[i+1];
+	map[val1] = val2;
+	map[val2] = val1;
+}
+
 
 const obfBlock = number => {
 	if (map[number] === undefined) throw new Error(`Invalid IP: ${number}`);
@@ -47,23 +30,8 @@ const obfBlock = number => {
 module.exports.obfBlock = obfBlock; // For testing purposes, should not be used in production.
 
 module.exports.obfIP = ip => {
-	if (!map) return null;
 	const data = ip.split(':');
-	return (
-		obfBlock(data[0]) +
-		':' +
-		obfBlock(data[1]) +
-		':' +
-		obfBlock(data[2]) +
-		':' +
-		obfBlock(data[3]) +
-		':' +
-		obfBlock(data[4]) +
-		':' +
-		obfBlock(data[5]) +
-		':' +
-		obfBlock(data[6]) +
-		':' +
-		obfBlock(data[7])
-	);
+	return data.slice(0, 8)
+		.map(obfBlock)
+		.join(":");
 };

--- a/src/frontend-scripts/constants.js
+++ b/src/frontend-scripts/constants.js
@@ -29,6 +29,7 @@ const CONTRIBUTORS = (module.exports.CONTRIBUTORS = [
 	'nth',
 	'OuchYouHitMe',
 	'PeeOnBus',
+	'Petey',
 	'Royal2000H',
 	'sethe',
 	'Skyrra',


### PR DESCRIPTION
### Simplified convertToHex
See below for unit test.
```
let b = num => num.toString(16).padStart(4, "0")
for (let a = 0; a < 16 * 16 * 16 * 16; a++) {
if(convertToHex(a) !== b(a))console.error(`Failed for ${a}`);
}
```

### Simplified objIP
Rewrote the function with JS stream syntax

### Rewrote map generation
The old code was slow because it was constantly removing elements from the middle of arrays. This is inefficient because we have to shift the elements in front everytime we do this. It's a lot faster to first randomize the array and then process it sequentially. This takes around 200 ms on my Surface to execute.