### PR TITLE
Included sourcemaps in prod webpack config

### DIFF
--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -25,6 +25,7 @@ module.exports = {
 			})
 		]
 	},
+	devtool: 'cheap-module-source-map',
 	module: {
 		rules: [
 			{


### PR DESCRIPTION
More information on source maps can be found [here](https://webpack.js.org/configuration/devtool/). 

@Hexicube was trying to figure out how to include meaningful debugging symbols in the production bundle. Including source maps should solve this issue.