### PR TITLE
Auto comp

### DIFF
--- a/models/gamestatistics.js
+++ b/models/gamestatistics.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+const Gamestatistics = new Schema({
+	rebalance6p: Boolean,
+	rebalance7p: Boolean,
+	rebalance9p: Boolean,
+	rerebalance9p: Boolean,
+	rebalance9p2f: Boolean,
+	fascistBias: Number,
+	liberalBias: Number
+});
+
+module.exports = mongoose.model('GameStatistics', Gamestatistics);

--- a/models/gamestatistics.js
+++ b/models/gamestatistics.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const { Schema } = mongoose;
 const Gamestatistics = new Schema({
+	isRainbow: Boolean,
 	rebalance6p: Boolean,
 	rebalance7p: Boolean,
 	rebalance9p: Boolean,

--- a/routes/socket/game/end-game.js
+++ b/routes/socket/game/end-game.js
@@ -163,9 +163,10 @@ module.exports.completeGame = (game, winningTeamName) => {
 				const isRainbow = game.general.rainbowgame;
 				const isTournamentFinalGame = game.general.isTourny && game.general.tournyInfo.round === 2;
 				const { rebalance6p, rebalance7p, rebalance9p, rerebalance9p, rebalance9p2f } = game;
-				GameStatistics.findOne({ rebalance6p, rebalance7p, rebalance9p, rerebalance9p, rebalance9p2f }).then(stats => {
+				GameStatistics.findOne({ isRainbow, rebalance6p, rebalance7p, rebalance9p, rerebalance9p, rebalance9p2f }).then(stats => {
 					if (!stats) {
 						stats = new GameStatistics({
+							isRainbow,
 							rebalance6p,
 							rebalance7p,
 							rebalance9p,

--- a/routes/socket/util.js
+++ b/routes/socket/util.js
@@ -129,50 +129,71 @@ module.exports.sendPlayerChatUpdate = (game, chat) => {
 
 module.exports.secureGame = secureGame;
 
-const avg = (accounts, accessor) => accounts.reduce((prev, curr) => prev + accessor(curr), 0) / accounts.length;
+const formTeams = (game, accounts, winningPlayerNames) => {
+	const losingPlayerNames = game.private.seatedPlayers
+		.filter(p => !winningPlayerNames.includes(p.userName))
+		.map(p => p.userName);
+	const winners = accounts.filter(account => winningPlayerNames.includes(account.username));
+	const losers = accounts.filter(account => losingPlayerNames.includes(account.username));
+	const libWin = game.gameState.isCompleted === 'liberal';
+	return {'liberals': libWin ? winners : losers, 'fascists': libWin ? losers : winners};
+};
 
-module.exports.rateEloGame = (game, accounts, winningPlayerNames) => {
+const avg = (accounts, accessor, defaultELO) => {
+	return accounts.reduce((prev, curr) => prev + (accessor(curr) || defaultELO), 0) / accounts.length;
+};
+
+const agragateRanks = (game, liberals, fascists, gameStatistics, defaultELO, accessor) => {
+	// Average each team's rank
+	const lAvg = avg(liberals, accessor, defaultELO);
+	const fAvg = avg(fascists, accessor, defaultELO);
+	// Adjust each team
+	const lRank = lAvg + (gameStatistics.liberalBias || defaultELO);
+	const fRank = fAvg + (gameStatistics.fascistBias || defaultELO);
+	// Calculate the rank difference
+	const libWin = game.gameState.isCompleted === 'liberal';
+	return libWin ? lRank - fRank : fRank - lRank;
+};
+
+const updateRating = (delta) => 1 / (1 + Math.pow(10, delta / 400));
+
+module.exports.rateEloGame = (game, accounts, winningPlayerNames, gameStatistics) => {
 	// ELO constants
 	const defaultELO = 1600;
-	const libAdjust = {
-		5: -19.253,
-		6: 20.637,
-		7: -17.282,
-		8: 45.418,
-		9: -70.679,
-		10: -31.539
-	};
-	const rk = 12;
-	const nk = 3;
-	// Players
-	const losingPlayerNames = game.private.seatedPlayers.filter(player => !winningPlayerNames.includes(player.userName)).map(player => player.userName);
-	// Accounts
-	const winningAccounts = accounts.filter(account => winningPlayerNames.includes(account.username));
-	const loosingAccounts = accounts.filter(account => losingPlayerNames.includes(account.username));
-	// Construct some basic statistics for each team
-	const b = game.gameState.isCompleted === 'liberal' ? 1 : 0;
 	const size = game.private.seatedPlayers.length;
-	const averageRatingWinners = avg(winningAccounts, a => a.eloOverall || defaultELO) + b * libAdjust[size];
-	const averageRatingWinnersSeason = avg(winningAccounts, a => a.eloSeason || defaultELO) + b * libAdjust[size];
-	const averageRatingLosers = avg(loosingAccounts, a => a.eloOverall || defaultELO) + (1 - b) * libAdjust[size];
-	const averageRatingLosersSeason = avg(loosingAccounts, a => a.eloSeason || defaultELO) + (1 - b) * libAdjust[size];
-	// Elo Formula
-	const k = size * (game.general.rainbowgame ? rk : nk); // non-rainbow games are capped at k/r
-	const winFactor = k / winningPlayerNames.length;
-	const loseFactor = -k / losingPlayerNames.length;
-	const p = 1 / (1 + Math.pow(10, (averageRatingWinners - averageRatingLosers) / 400));
-	const pSeason = 1 / (1 + Math.pow(10, (averageRatingWinnersSeason - averageRatingLosersSeason) / 400));
+	const k = size * (game.general.rainbowgame ? 12 : 3);
+	const libWin = game.gameState.isCompleted === 'liberal';
+	const comp = 4;
+	// Average each team's rank
+  const { liberals, fascists } = formTeams(game, accounts, winningPlayerNames);
+	const deltaOverall = agragateRanks(game, liberals, fascists, gameStatistics, defaultELO, a => a.eloOverall);
+	const deltaSeason = agragateRanks(game, liberals, fascists, gameStatistics, defaultELO, a => a.eloSeason);
+	// Apply rating
+	const pOverall = updateRating(deltaOverall);
+	const pSeason = updateRating(deltaSeason);
+	// Update bias
+	gameStatistics.liberalBias = (gameStatistics.liberalBias || defaultELO) + ((libWin ? 1 : -1 ) * pOverall * comp);
+	gameStatistics.fascistBias = (gameStatistics.fascistBias || defaultELO) + ((libWin ? -1 : 1 ) * pOverall * comp);
+	gameStatistics.save();
+	// Calculate distribution
+	const lFactor = k / liberals.length;
+	const fFactor = k / fascists.length;
+	const winFactor = libWin ? lFactor : fFactor;
+	const loseFactor = -(libWin ? fFactor : lFactor);
+	// Apply the changes to all players
 	let ratingUpdates = {};
 	accounts.forEach(account => {
-		const eloOverall = account.eloOverall ? account.eloOverall : defaultELO;
-		const eloSeason = account.eloSeason ? account.eloSeason : defaultELO;
-		const factor = winningPlayerNames.includes(account.username) ? winFactor : loseFactor;
-		const change = p * factor;
-		const changeSeason = pSeason * factor;
-		account.eloOverall = eloOverall + change;
-		account.eloSeason = eloSeason + changeSeason;
+		const isWinner = winningPlayerNames.includes(account.username);
+		const factor = isWinner ? winFactor : loseFactor;
+		// Apply overall elo change
+		const updateOverall = pOverall * factor;
+		account.eloOverall = (account.eloOverall || defaultELO) + updateOverall;
+		// Apply seasonal elo change
+		const updateSeason = pSeason * factor;
+		account.eloSeason = (account.eloSeason || defaultELO) + updateSeason;
+
 		account.save();
-		ratingUpdates[account.username] = { change, changeSeason };
+		ratingUpdates[account.username] = { change: updateOverall, changeSeason: updateSeason };
 	});
 	return ratingUpdates;
 };

--- a/src/frontend-scripts/components/section-main/Changelog.jsx
+++ b/src/frontend-scripts/components/section-main/Changelog.jsx
@@ -9,6 +9,15 @@ const Changelog = () => (
 			<h2>Changelog</h2>
 		</div>
 		<div className="ui header">
+			<p>//VERSION_ME!//</p>
+		</div>
+		<h4>New feature: Game bias compensation</h4>
+		<p>
+			The elo formula has been updated to automatically calculate the team bias of every game size. Each game size has an Elo score which is added to both
+			teams. There are different biases for rainbow and non-rainbow games. In the long run, this should mean that no specific size of game gives better or
+			worse elo returns. However, these values may take some time to approximate the team bases. Expect a week of slightly unstable Elo returns.
+		</p>
+		<div className="ui header">
 			<p>Version 1.0.0-beta4 released 12-4-2018</p>
 		</div>
 		<h3>Some attempts to fix issues with server instability, few smaller things, thats about it.</h3>


### PR DESCRIPTION
### New feature: Game bias compensation

The elo formula has been updated to automatically calculate the team bias of every game size. Each game size has an Elo score which is added to both teams. There are different biases for rainbow and non-rainbow games. In the long run, this should mean that no specific size of game gives better or worse elo returns. However, these values may take some time to approximate the team bases. Expect a week of slightly unstable Elo returns.

---

Adds a new collection of team biases for each game size, and incorporate it into the elo calculation. Needs:
- [ ] testing that this doesn't break custom games