### PR TITLE
Various remake changes

### DIFF
--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -324,25 +324,10 @@ const handleUserLeaveGame = (socket, game, data, passport) => {
 	if (playerIndex > -1) {
 		if (game.publicPlayersState[playerIndex].isRemakeVoting) {
 			// Count leaving the game as rescinded remake vote.
-			const minimumRemakeVoteCount = (() => {
-				switch (game.general.playerCount) {
-					case 5:
-						return 4;
-					case 6:
-						return 5;
-					case 7:
-						return 5;
-					case 8:
-						return 6;
-					case 9:
-						return 6;
-					case 10:
-						return 7;
-				}
-			})();
+			const minimumRemakeVoteCount = (game.general.playerCount - game.customGameSettings.fascistCount);
 			const remakePlayerCount = game.publicPlayersState.filter(player => player.isRemakeVoting).length;
 
-			if (game.general.isRemaking && remakePlayerCount <= minimumRemakeVoteCount) {
+			if (game.general.isRemaking && remakePlayerCount < minimumRemakeVoteCount) {
 				game.general.isRemaking = false;
 				game.general.status = 'Game remaking has been cancelled.';
 				clearInterval(game.private.remakeTimer);
@@ -1225,22 +1210,7 @@ module.exports.handleUpdatedRemakeGame = (passport, game, data) => {
 	/**
 	 * @return {number} minimum number of remake votes to remake a game
 	 */
-	const minimumRemakeVoteCount = (() => {
-		switch (game.general.playerCount) {
-			case 5:
-				return 4;
-			case 6:
-				return 5;
-			case 7:
-				return 5;
-			case 8:
-				return 6;
-			case 9:
-				return 6;
-			case 10:
-				return 7;
-		}
-	})();
+	const minimumRemakeVoteCount = (game.general.playerCount - game.customGameSettings.fascistCount);
 	const chat = {
 		timestamp: new Date(),
 		gameChat: true,
@@ -1483,7 +1453,9 @@ module.exports.handleUpdatedRemakeGame = (passport, game, data) => {
 	} else {
 		const remakePlayerCount = publicPlayersState.filter(player => player.isRemakeVoting).length;
 
-		if (game.general.isRemaking && remakePlayerCount <= minimumRemakeVoteCount) {
+		player.isRemaking = false;
+
+		if (game.general.isRemaking && remakePlayerCount < minimumRemakeVoteCount) {
 			game.general.isRemaking = false;
 			game.general.status = 'Game remaking has been cancelled.';
 			clearInterval(game.private.remakeTimer);


### PR DESCRIPTION
1.-Minimum amount of votes required to remake is amount of libs plus one.

2.-Remake cancels only when players that voted for remake are LESS than the minimum of votes required to remake.

3.-player.isRemaking is set to false when remake vote is set to false as well, i think this is the cause of the remake bug where people get remade even if they didnt want to (This needs to be added when player leaves the game as well, but i dont know how to, so i didnt do it)

*This branch was untested, needs testing