### PR TITLE
Update Creategame.jsx

### DIFF
--- a/src/frontend-scripts/components/section-main/Creategame.jsx
+++ b/src/frontend-scripts/components/section-main/Creategame.jsx
@@ -567,7 +567,7 @@ export default class Creategame extends React.Component {
 		const isSeason = (userInfo.gameSettings && !userInfo.gameSettings.disableSeasonal) || false;
 		const playerElo = (player && Math.min(2000, player.eloSeason)) || 2000;
 		const playerEloNonseason = (player && Math.min(2000, player.eloOverall)) || 2000;
-		const max = Math.min(playerElo, playerEloNonseason);
+		const max = Math.max(playerElo, playerEloNonseason);
 		const marks = Object.keys(origMarks)
 			.filter(k => origMarks[k] <= max)
 			.reduce((obj, key) => {


### PR DESCRIPTION
Elo slider is now based on the max value of overall or seasonal Elo, instead of the min. This means that when seasons reset players can continue to create Elo limited games using the slider up to their overall Elo which may be considerably higher than the default seasonal 1600.