### PR TITLE
Adds forceskip  functionality.

### DIFF
--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -14,6 +14,7 @@ const {
 } = require('./models');
 const { sendGameList, sendUserList, updateUserStatus, sendGameInfo, sendUserReports, sendPlayerNotes } = require('./user-requests');
 const { selectVoting } = require('./game/election.js');
+const { selectChancellor } = require('./game/election-util.js');
 const Account = require('../../models/account');
 const ModAction = require('../../models/modAction');
 const PlayerReport = require('../../models/playerReport');
@@ -1628,6 +1629,76 @@ module.exports.handleAddNewGameChat = (socket, passport, data, modUserNames, edi
 				}
 			];
 			selectVoting({ user: affectedPlayer.userName }, game, { vote });
+			sendPlayerChatUpdate(game, data);
+			return;
+		}
+	}
+
+	if (AEM) {
+		const aemSkip = /forceskip (\d{1,2})/i.exec(chat);
+		if (aemSkip) {
+			if (player) {
+				socket.emit('sendAlert', 'You cannot force skip a government whilst playing.');
+				return;
+			}
+			const affectedPlayerNumber = parseInt(aemSkip[1]) - 1;
+			const affectedPlayer = game.private.seatedPlayers[affectedPlayerNumber];
+			if (!affectedPlayer) {
+				socket.emit('sendAlert', `There is no seat ${affectedPlayerNumber + 1}.`);
+				return;
+			}
+			if (affectedPlayerNumber !== game.gameState.presidentIndex) {
+				socket.emit('sendAlert', `The player in seat ${affectedPlayerNumber + 1} is not president.`);
+				return;
+			}
+			let chancellor = -1;
+			let currentPlayers = [];
+			for (let i = 0; i < game.private.seatedPlayers.length; i++) {
+				if (game.private.seatedPlayers[i].isDead) {
+					currentPlayers[i] = false;
+				} else if (i === game.gameState.previousElectedGovernment[0] && game.general.livingPlayerCount > 5) {
+					currentPlayers[i] = false;
+				} else if (i === game.gameState.previousElectedGovernment[1]) {
+					currentPlayers[i] = false;
+				} else {
+					currentPlayers[i] = true;
+				}
+			}
+			currentPlayers[affectedPlayerNumber] = false;
+			let counter = affectedPlayerNumber + 1;
+			while (chancellor === -1) {
+				if (counter >= currentPlayers.length) {
+					counter = 0;
+				}
+				if (currentPlayers[counter]) {
+					chancellor = counter;
+				}
+				counter++;
+			}
+			game.private.unSeatedGameChats = [
+				{
+					gameChat: true,
+					timestamp: new Date(),
+					chat: [
+						{
+							text: 'An AEM member has force skipped the government with '
+						},
+						{
+							text: `${affectedPlayer.userName} {${affectedPlayerNumber + 1}}`,
+							type: 'player'
+						},
+						{
+							text: ' as president.'
+						}
+					]
+				}
+			];
+			selectChancellor(null, { user: affectedPlayer.userName }, game, { chancellorIndex: chancellor });
+			setTimeout(() => {
+				for (let p of game.private.seatedPlayers.filter(player => !player.isDead)) {
+					selectVoting({ user: p.userName }, game, { vote: false });
+				}
+			}, 1000);
 			sendPlayerChatUpdate(game, data);
 			return;
 		}


### PR DESCRIPTION
Allows an AEM member to auto-pick a chancellor for a president, and force nein it, resulting the government being essentially skipped, but gracefully.

Syntax:  `forceskip <president seat>`