### PR TITLE
Adds ability for mods to peek at currently locked in votes

### DIFF
--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -2194,6 +2194,31 @@ module.exports.handleModerationAction = (socket, passport, data, skipCheck, modU
 						if (err) socket.emit('sendAlert', `IP clear failed:\n${err}`);
 					});
 					break;
+				case 'modPeekVotes':
+					const gameToPeek = games[data.uid];
+					let output = '';
+					if (gameToPeek && gameToPeek.private && gameToPeek.private.seatedPlayers) {
+						const playersToCheckVotes = gameToPeek.private.seatedPlayers;
+						playersToCheckVotes.map(player => {
+							output += 'Seat ' + (playersToCheckVotes.indexOf(player)+1) + ' - ';
+							if (player && player.role && player.role.cardName) {
+								if (player.role.cardName === 'hitler') {
+									output += player.role.cardName.substring(0, 1).toUpperCase() + player.role.cardName.substring(1) + '   - ';
+								}
+								else {
+									output += player.role.cardName.substring(0, 1).toUpperCase() + player.role.cardName.substring(1) + ' - ';
+								}
+							}
+							else {
+								output += 'Roles not Dealt - ';
+							}
+							output += player.voteStatus && player.voteStatus.hasVoted ? (player.voteStatus.didVoteYes ? 'Ja' : 'Nein') : 'Not' +
+								' Voted';
+							output += '\n';
+						});
+					}
+					socket.emit('sendAlert', output);
+					break;
 				case 'modEndGame':
 					const gameToEnd = games[data.uid];
 

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -305,6 +305,15 @@ class Gamechat extends React.Component {
 		);
 	}
 
+	isPlayerInGame(players, username) {
+		players.map( player => {
+			if (player.userName === username) {
+				return true;
+			}
+		});
+		return false;
+	}
+
 	gameChatStatus = () => {
 		const { userInfo, gameInfo } = this.props;
 		const { gameState, publicPlayersState } = gameInfo;
@@ -689,6 +698,16 @@ class Gamechat extends React.Component {
 			);
 		};
 
+		const modGetCurrentVotes = () => {
+			socket.emit('updateModAction', {
+				modName: userInfo.userName,
+				userName: userInfo.userName,
+				comment: `Peek votes for ${gameInfo.general.uid}`,
+				uid: gameInfo.general.uid,
+				action: 'modPeekVotes'
+			});
+		};
+
 		const sendModEndGame = winningTeamName => {
 			socket.emit('updateModAction', {
 				modName: userInfo.userName,
@@ -735,8 +754,14 @@ class Gamechat extends React.Component {
 							style={{ color: showFullChat ? '#4169e1' : 'indianred' }}
 						/>
 					</a>
-					{isStaff && gameInfo && gameInfo.gameState && gameInfo.gameState.isStarted && this.renderModEndGameButtons()}
-
+					{!this.isPlayerInGame(gameInfo.publicPlayersState, userInfo.username) && isStaff && gameInfo && gameInfo.gameState && gameInfo.gameState.isStarted && this.renderModEndGameButtons()}
+					{!this.isPlayerInGame(gameInfo.publicPlayersState, userInfo.username) && isStaff && gameInfo && gameInfo.gameState && gameInfo.gameState.isStarted && (
+						<div>
+							<div className="ui button primary" onClick={() => modGetCurrentVotes()} style={{ width: '60px' }}>
+								Peek Votes
+							</div>
+						</div>
+					)}
 					{gameInfo.general &&
 						gameInfo.general.tournyInfo &&
 						(gameInfo.general.tournyInfo.showOtherTournyTable || gameInfo.general.tournyInfo.isRound1TableThatFinished2nd) && (


### PR DESCRIPTION
Sends an alert to requesting mod, with information in a nice format. 
![image](https://user-images.githubusercontent.com/19434157/52321857-59d0bd80-299c-11e9-8e47-a43d95c53425.png)


**This PR:**
All tests pass
![image](https://user-images.githubusercontent.com/19434157/52321864-648b5280-299c-11e9-9975-276cb4003784.png)

✅ Peek Votes button only appears if the requesting mod isn't in the game
✅ Peek Votes button does trigger a modlog entry
✅ Mod End Game button now does not show up when the requesting mod isn't in the game
✅ Peek Votes cleanly handles: Pre-Game, Mid-Game, and Post-Game situations