### PR TITLE
Allows players to claim directly from the chat line - [Officially Finished and Mergable]

### DIFF
--- a/routes/socket/game/policy-powers.js
+++ b/routes/socket/game/policy-powers.js
@@ -489,6 +489,7 @@ module.exports.selectBurnCard = (passport, game, data) => {
 
 				publicPresident.cardStatus.isFlipped = true;
 
+				president.cardFlingerState = [];
 				if (data.vote) {
 					game.private.policies.shift();
 					game.gameState.undrawnPolicyCount--;

--- a/routes/socket/routes.js
+++ b/routes/socket/routes.js
@@ -202,7 +202,7 @@ module.exports = (modUserNames, editorUserNames, adminUserNames, altmodUserNames
 			socket.on('addNewClaim', data => {
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					handleAddNewClaim(passport, game, data);
+					handleAddNewClaim(socket, passport, game, data);
 				}
 			});
 			socket.on('updateGameWhitelist', data => {
@@ -215,9 +215,10 @@ module.exports = (modUserNames, editorUserNames, adminUserNames, altmodUserNames
 				handleUpdatedTruncateGame(data);
 			});
 			socket.on('addNewGameChat', data => {
+				const game = findGame(data);
 				if (isRestricted) return;
 				if (authenticated) {
-					handleAddNewGameChat(socket, passport, data, modUserNames, editorUserNames, adminUserNames);
+					handleAddNewGameChat(socket, passport, data, game, modUserNames, editorUserNames, adminUserNames, handleAddNewClaim);
 				}
 			});
 			socket.on('updateReportGame', data => {

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -828,11 +828,12 @@ module.exports.handleAddNewGame = (socket, passport, data) => {
 };
 
 /**
+ * @param {object} socket - user socket reference.
  * @param {object} passport - socket authentication.
  * @param {object} game - target game.
  * @param {object} data - from socket emit.
  */
-module.exports.handleAddNewClaim = (passport, game, data) => {
+module.exports.handleAddNewClaim = (socket, passport, game, data) => {
 	const playerIndex = game.publicPlayersState.findIndex(player => player.userName === passport.user);
 
 	if (!game.private || !game.private.summary || game.publicPlayersState[playerIndex].isDead) {
@@ -841,8 +842,7 @@ module.exports.handleAddNewClaim = (passport, game, data) => {
 	const { blindMode, replacementNames } = game.general;
 
 	const chat = (() => {
-		let text;
-
+		let text, claimString, redCount, blueCount, cardList;
 		switch (data.claim) {
 			case 'wasPresident':
 				text = [
@@ -854,105 +854,44 @@ module.exports.handleAddNewClaim = (passport, game, data) => {
 						type: 'player'
 					}
 				];
-				switch (data.claimState) {
-					case 'threefascist':
-						game.private.summary = game.private.summary.updateLog(
-							{
-								presidentClaim: { reds: 3, blues: 0 }
-							},
-							{ presidentId: playerIndex }
-						);
-
-						text.push(
-							{
-								text: 'claims '
-							},
-							{
-								text: 'RRR',
-								type: 'fascist'
-							},
-							{
-								text: '.'
-							}
-						);
-
-						return text;
-					case 'twofascistoneliberal':
-						game.private.summary = game.private.summary.updateLog(
-							{
-								presidentClaim: { reds: 2, blues: 1 }
-							},
-							{ presidentId: playerIndex }
-						);
-
-						text.push(
-							{
-								text: 'claims '
-							},
-							{
-								text: 'RR',
-								type: 'fascist'
-							},
-							{
-								text: 'B',
-								type: 'liberal'
-							},
-							{
-								text: '.'
-							}
-						);
-
-						return text;
-					case 'twoliberalonefascist':
-						game.private.summary = game.private.summary.updateLog(
-							{
-								presidentClaim: { reds: 1, blues: 2 }
-							},
-							{ presidentId: playerIndex }
-						);
-
-						text.push(
-							{
-								text: 'claims '
-							},
-							{
-								text: 'R',
-								type: 'fascist'
-							},
-							{
-								text: 'BB',
-								type: 'liberal'
-							},
-							{
-								text: '.'
-							}
-						);
-
-						return text;
-					case 'threeliberal':
-						game.private.summary = game.private.summary.updateLog(
-							{
-								presidentClaim: { reds: 0, blues: 3 }
-							},
-							{ presidentId: playerIndex }
-						);
-
-						text.push(
-							{
-								text: 'claims '
-							},
-							{
-								text: 'BBB',
-								type: 'liberal'
-							},
-							{
-								text: '.'
-							}
-						);
-
-						return text;
+				claimString = data.claimState;
+				redCount = 0;
+				blueCount = 0;
+				cardList = [];
+				for (let char of claimString) {
+					if (char.toUpperCase() === 'R') {
+						redCount++;
+						cardList.push({
+							text: 'R',
+							type: 'fascist'
+						});
+					} else if (char.toUpperCase() === 'B') {
+						blueCount++;
+						cardList.push({
+							text: 'B',
+							type: 'liberal'
+						});
+					}
 				}
+				game.private.summary = game.private.summary.updateLog(
+					{
+						presidentClaim: { reds: redCount, blues: blueCount }
+					},
+					{ presidentId: playerIndex }
+				);
 
+				text.push(
+					{
+						text: 'claims '
+					},
+					cardList[0],
+					cardList[1],
+					cardList[2],
+					{
+						text: '.'
+					}
+				);
+				return text;
 			case 'wasChancellor':
 				text = [
 					{
@@ -963,78 +902,43 @@ module.exports.handleAddNewClaim = (passport, game, data) => {
 						type: 'player'
 					}
 				];
-				switch (data.claimState) {
-					case 'twofascist':
-						game.private.summary = game.private.summary.updateLog(
-							{
-								chancellorClaim: { reds: 2, blues: 0 }
-							},
-							{ chancellorId: playerIndex }
-						);
-
-						text.push(
-							{
-								text: 'claims '
-							},
-							{
-								text: 'RR',
-								type: 'fascist'
-							},
-							{
-								text: '.'
-							}
-						);
-
-						return text;
-					case 'onefascistoneliberal':
-						game.private.summary = game.private.summary.updateLog(
-							{
-								chancellorClaim: { reds: 1, blues: 1 }
-							},
-							{ chancellorId: playerIndex }
-						);
-
-						text.push(
-							{
-								text: 'claims '
-							},
-							{
-								text: 'R',
-								type: 'fascist'
-							},
-							{
-								text: 'B',
-								type: 'liberal'
-							},
-							{
-								text: '.'
-							}
-						);
-
-						return text;
-					case 'twoliberal':
-						game.private.summary = game.private.summary.updateLog(
-							{
-								chancellorClaim: { reds: 0, blues: 2 }
-							},
-							{ chancellorId: playerIndex }
-						);
-
-						text.push(
-							{
-								text: 'claims '
-							},
-							{
-								text: 'BB',
-								type: 'liberal'
-							},
-							{
-								text: '.'
-							}
-						);
-
-						return text;
+				claimString = data.claimState;
+				redCount = 0;
+				blueCount = 0;
+				cardList = [];
+				for (let char of claimString) {
+					if (char.toUpperCase() === 'R') {
+						redCount++;
+						cardList.push({
+							text: 'R',
+							type: 'fascist'
+						});
+					} else if (char.toUpperCase() === 'B') {
+						blueCount++;
+						cardList.push({
+							text: 'B',
+							type: 'liberal'
+						});
+					}
 				}
+				game.private.summary = game.private.summary.updateLog(
+					{
+						presidentClaim: { reds: redCount, blues: blueCount }
+					},
+					{ presidentId: playerIndex }
+				);
+
+				text.push(
+					{
+						text: 'claims '
+					},
+					cardList[0],
+					cardList[1],
+					{
+						text: '.'
+					}
+				);
+				return text;
 			case 'didSinglePolicyPeek':
 				if (data.claimState === 'liberal' || data.claimState === 'fascist') {
 					text = [
@@ -1058,6 +962,7 @@ module.exports.handleAddNewClaim = (passport, game, data) => {
 					];
 					return text;
 				}
+				break;
 			case 'didPolicyPeek':
 				text = [
 					{
@@ -1068,104 +973,44 @@ module.exports.handleAddNewClaim = (passport, game, data) => {
 						type: 'player'
 					}
 				];
-				switch (data.claimState) {
-					case 'threefascist':
-						game.private.summary = game.private.summary.updateLog(
-							{
-								policyPeekClaim: { reds: 3, blues: 0 }
-							},
-							{ presidentId: playerIndex }
-						);
-
-						text.push(
-							{
-								text: 'claims to have peeked at '
-							},
-							{
-								text: 'RRR',
-								type: 'fascist'
-							},
-							{
-								text: '.'
-							}
-						);
-
-						return text;
-					case 'twofascistoneliberal':
-						game.private.summary = game.private.summary.updateLog(
-							{
-								policyPeekClaim: { reds: 2, blues: 1 }
-							},
-							{ presidentId: playerIndex }
-						);
-
-						text.push(
-							{
-								text: 'claims to have peeked at '
-							},
-							{
-								text: 'RR',
-								type: 'fascist'
-							},
-							{
-								text: 'B',
-								type: 'liberal'
-							},
-							{
-								text: '.'
-							}
-						);
-
-						return text;
-					case 'twoliberalonefascist':
-						game.private.summary = game.private.summary.updateLog(
-							{
-								policyPeekClaim: { reds: 1, blues: 2 }
-							},
-							{ presidentId: playerIndex }
-						);
-
-						text.push(
-							{
-								text: 'claims to have peeked at '
-							},
-							{
-								text: 'R',
-								type: 'fascist'
-							},
-							{
-								text: 'BB',
-								type: 'liberal'
-							},
-							{
-								text: '.'
-							}
-						);
-
-						return text;
-					case 'threeliberal':
-						game.private.summary = game.private.summary.updateLog(
-							{
-								policyPeekClaim: { reds: 0, blues: 3 }
-							},
-							{ presidentId: playerIndex }
-						);
-
-						text.push(
-							{
-								text: 'claims to have peeked at '
-							},
-							{
-								text: 'BBB',
-								type: 'liberal'
-							},
-							{
-								text: '.'
-							}
-						);
-
-						return text;
+				claimString = data.claimState;
+				redCount = 0;
+				blueCount = 0;
+				cardList = [];
+				for (let char of claimString) {
+					if (char.toUpperCase() === 'R') {
+						redCount++;
+						cardList.push({
+							text: 'R',
+							type: 'fascist'
+						});
+					} else if (char.toUpperCase() === 'B') {
+						blueCount++;
+						cardList.push({
+							text: 'B',
+							type: 'liberal'
+						});
+					}
 				}
+				game.private.summary = game.private.summary.updateLog(
+					{
+						presidentClaim: { reds: redCount, blues: blueCount }
+					},
+					{ presidentId: playerIndex }
+				);
+
+				text.push(
+					{
+						text: 'claims to have peeked at '
+					},
+					cardList[0],
+					cardList[1],
+					cardList[2],
+					{
+						text: '.'
+					}
+				);
+				return text;
 			case 'didInvestigateLoyalty':
 				text = [
 					{
@@ -1233,9 +1078,9 @@ module.exports.handleAddNewClaim = (passport, game, data) => {
 			claim: data.claim,
 			claimState: data.claimState
 		};
-
 		game.chats.push(claimChat);
-		sendInProgressGameUpdate(game);
+		socket.emit('removeClaim');
+		sendInProgressGameUpdate(game, false);
 	}
 };
 
@@ -1528,16 +1373,18 @@ module.exports.handleUpdatedRemakeGame = (passport, game, data) => {
  * @param {object} socket - socket reference.
  * @param {object} passport - socket authentication.
  * @param {object} data - from socket emit.
+ * @param {object} game - target game.
  * @param {array} modUserNames - list of mods
  * @param {array} editorUserNames - list of editors
  * @param {array} adminUserNames - list of admins
+ * @param {function} addNewClaim - links to handleAddNewClaim()
  */
-module.exports.handleAddNewGameChat = (socket, passport, data, modUserNames, editorUserNames, adminUserNames) => {
+module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserNames, editorUserNames, adminUserNames, addNewClaim) => {
 	// Authentication Assured in routes.js
-	const game = games[data.uid];
 	if (!game || !game.general || game.general.disableChat || !data.chat) return;
 	const chat = data.chat.trim();
 	const staffUserNames = [...modUserNames, ...editorUserNames, ...adminUserNames];
+	const playerIndex = game.publicPlayersState.findIndex(player => player.userName === passport.user);
 
 	if (chat.length > 300 || !chat.length) {
 		return;
@@ -1545,7 +1392,6 @@ module.exports.handleAddNewGameChat = (socket, passport, data, modUserNames, edi
 
 	const { publicPlayersState } = game;
 	const player = publicPlayersState.find(player => player.userName === passport.user);
-
 	const user = userList.find(u => passport.user === u.userName);
 
 	if (!user || game.general.disableChat) {
@@ -1553,6 +1399,39 @@ module.exports.handleAddNewGameChat = (socket, passport, data, modUserNames, edi
 	}
 
 	data.userName = passport.user;
+
+	if (/^[RB]{2,3}$/i.exec(chat)) {
+		if (chat.length === 3 && 0 <= playerIndex <= 9 && game.private.seatedPlayers[playerIndex].playersState[playerIndex].claim === 'wasPresident') {
+			const claimData = {
+				userName: user.userName,
+				claimState: chat,
+				claim: game.private.seatedPlayers[playerIndex].playersState[playerIndex].claim,
+				uid: data.uid
+			};
+			addNewClaim(socket, passport, game, claimData);
+			return;
+		}
+		if (chat.length === 2 && 0 <= playerIndex <= 9 && game.private.seatedPlayers[playerIndex].playersState[playerIndex].claim === 'wasChancellor') {
+			const claimData = {
+				userName: user.userName,
+				claimState: chat,
+				claim: game.private.seatedPlayers[playerIndex].playersState[playerIndex].claim,
+				uid: data.uid
+			};
+			addNewClaim(socket, passport, game, claimData);
+			return;
+		}
+		if (chat.length === 3 && 0 <= playerIndex <= 9 && game.private.seatedPlayers[playerIndex].playersState[playerIndex].claim === 'didPolicyPeek') {
+			const claimData = {
+				userName: user.userName,
+				claimState: chat,
+				claim: game.private.seatedPlayers[playerIndex].playersState[playerIndex].claim,
+				uid: data.uid
+			};
+			addNewClaim(socket, passport, game, claimData);
+			return;
+		}
+	}
 
 	const AEM = staffUserNames.includes(passport.user) || newStaff.modUserNames.includes(passport.user) || newStaff.editorUserNames.includes(passport.user);
 	if (!AEM) {
@@ -1569,6 +1448,7 @@ module.exports.handleAddNewGameChat = (socket, passport, data, modUserNames, edi
 			}
 		}
 	}
+
 
 	const { gameState } = game;
 

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -51,6 +51,12 @@ class Gamechat extends React.Component {
 			window.location.hash = '#/';
 			$(this.leaveTournyQueueModal).modal('hide');
 		});
+
+		this.props.socket.on('removeClaim', () => {
+			this.setState({
+				claim: ''
+			});
+		});
 	}
 
 	componentDidUpdate(prevProps, nextProps) {
@@ -280,7 +286,6 @@ class Gamechat extends React.Component {
 	handleClickedClaimButton = () => {
 		const { gameInfo, userInfo } = this.props;
 		const playerIndex = gameInfo.publicPlayersState.findIndex(player => player.userName === userInfo.userName);
-
 		this.setState({
 			claim: this.state.claim ? '' : gameInfo.playersState[playerIndex].claim
 		});
@@ -788,7 +793,6 @@ class Gamechat extends React.Component {
 								e.preventDefault();
 
 								this.props.socket.emit('addNewClaim', chat);
-								this.setState({ claim: '' });
 							};
 
 							switch (this.state.claim) {
@@ -798,7 +802,7 @@ class Gamechat extends React.Component {
 											<p> As president, I drew...</p>
 											<button
 												onClick={e => {
-													handleClaimButtonClick(e, 'threefascist');
+													handleClaimButtonClick(e, 'rrr');
 												}}
 												className="ui button threefascist"
 											>
@@ -806,7 +810,7 @@ class Gamechat extends React.Component {
 											</button>
 											<button
 												onClick={e => {
-													handleClaimButtonClick(e, 'twofascistoneliberal');
+													handleClaimButtonClick(e, 'rrb');
 												}}
 												className="ui button twofascistoneliberal"
 											>
@@ -814,7 +818,7 @@ class Gamechat extends React.Component {
 											</button>
 											<button
 												onClick={e => {
-													handleClaimButtonClick(e, 'twoliberalonefascist');
+													handleClaimButtonClick(e, 'rbb');
 												}}
 												className="ui button twoliberalonefascist"
 											>
@@ -822,7 +826,7 @@ class Gamechat extends React.Component {
 											</button>
 											<button
 												onClick={e => {
-													handleClaimButtonClick(e, 'threeliberal');
+													handleClaimButtonClick(e, 'bbb');
 												}}
 												className="ui button threeliberal"
 											>
@@ -836,7 +840,7 @@ class Gamechat extends React.Component {
 											<p> As chancellor, I received...</p>
 											<button
 												onClick={e => {
-													handleClaimButtonClick(e, 'twofascist');
+													handleClaimButtonClick(e, 'rr');
 												}}
 												className="ui button threefascist"
 											>
@@ -844,7 +848,7 @@ class Gamechat extends React.Component {
 											</button>
 											<button
 												onClick={e => {
-													handleClaimButtonClick(e, 'onefascistoneliberal');
+													handleClaimButtonClick(e, 'rb');
 												}}
 												className="ui button onefascistoneliberal"
 											>
@@ -852,7 +856,7 @@ class Gamechat extends React.Component {
 											</button>
 											<button
 												onClick={e => {
-													handleClaimButtonClick(e, 'twoliberal');
+													handleClaimButtonClick(e, 'bb');
 												}}
 												className="ui button threeliberal"
 											>
@@ -910,7 +914,7 @@ class Gamechat extends React.Component {
 											<p> As president, I peeked and saw... </p>
 											<button
 												onClick={e => {
-													handleClaimButtonClick(e, 'threefascist');
+													handleClaimButtonClick(e, 'rrr');
 												}}
 												className="ui button threefascist"
 											>
@@ -918,7 +922,7 @@ class Gamechat extends React.Component {
 											</button>
 											<button
 												onClick={e => {
-													handleClaimButtonClick(e, 'twofascistoneliberal');
+													handleClaimButtonClick(e, 'rrb');
 												}}
 												className="ui button twofascistoneliberal"
 											>
@@ -926,7 +930,7 @@ class Gamechat extends React.Component {
 											</button>
 											<button
 												onClick={e => {
-													handleClaimButtonClick(e, 'twoliberalonefascist');
+													handleClaimButtonClick(e, 'rbb');
 												}}
 												className="ui button twoliberalonefascist"
 											>
@@ -934,7 +938,7 @@ class Gamechat extends React.Component {
 											</button>
 											<button
 												onClick={e => {
-													handleClaimButtonClick(e, 'threeliberal');
+													handleClaimButtonClick(e, 'bbb');
 												}}
 												className="ui button threeliberal"
 											>

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -982,6 +982,21 @@ class Gamechat extends React.Component {
 									The word "{this.state.badWord[1]}"{this.state.badWord[0] !== this.state.badWord[1] ? ` (${this.state.badWord[0]})` : ''} is forbidden.
 								</span>
 							)}
+							{(() => {
+								if (
+									gameInfo.playersState &&
+									gameInfo.playersState.length &&
+									userInfo.userName &&
+									gameInfo.playersState[gameInfo.publicPlayersState.findIndex(player => player.userName === userInfo.userName)].claim &&
+									!gameInfo.playersState[gameInfo.publicPlayersState.findIndex(player => player.userName === userInfo.userName)].isDead
+								) {
+									return (
+										<div className="claim-button" title="Click here to make a claim in chat" onClick={this.handleClickedClaimButton}>
+											<span style={{padding: '5px'}}>Claim</span>
+										</div>
+									);
+								}
+							})()}
 							<input
 								onSubmit={this.handleSubmit}
 								onChange={this.handleTyping}
@@ -999,21 +1014,6 @@ class Gamechat extends React.Component {
 								Chat
 							</button>
 						</div>
-						{(() => {
-							if (
-								gameInfo.playersState &&
-								gameInfo.playersState.length &&
-								userInfo.userName &&
-								gameInfo.playersState[gameInfo.publicPlayersState.findIndex(player => player.userName === userInfo.userName)].claim &&
-								!gameInfo.playersState[gameInfo.publicPlayersState.findIndex(player => player.userName === userInfo.userName)].isDead
-							) {
-								return (
-									<div className="claim-button" title="Click here to make a claim in chat" onClick={this.handleClickedClaimButton}>
-										Claim
-									</div>
-								);
-							}
-						})()}
 					</form>
 				)}
 				<div

--- a/src/scss/game.scss
+++ b/src/scss/game.scss
@@ -37,7 +37,7 @@
 				display: flex;
 				position: relative;
 				z-index: 100;
-				padding: 4px 10px 4px 10px;
+				padding: 4px 2px 4px 2px;
 			}
 
 			.gamechat-filters-container {
@@ -223,10 +223,9 @@
 			}
 			.inputbar {
 				.claim-button {
-					float: left;
 					color: #fbbd08;
 					font-style: italic;
-					padding: 12px 9px 8px 5px;
+					padding: 11px 10px 11px 7px;
 					font-size: 16px;
 					font-weight: 700;
 					z-index: 102;
@@ -236,12 +235,13 @@
 						content: '';
 						display: table;
 						animation: fadeIn 0.6s infinite alternate;
-						top: 2px;
+						top: 0;
 						left: 0;
 						position: absolute;
 						width: 100%;
-						height: 35px;
-						box-shadow: inset 0 0 3px 5px #fbbd08;
+						height: 100%;
+						box-shadow: inset 0 0 5px 5px #fbbd08;
+						border-radius: 5px;
 					}
 				}
 				.expando-container {

--- a/src/scss/players.scss
+++ b/src/scss/players.scss
@@ -43,6 +43,7 @@ $eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (190
 	background: #000;
 	height: 115px;
 	overflow: hidden;
+	margin-top: 5px;
 	> .label {
 		width: 50px;
 		margin: 28px 0 0 10px;


### PR DESCRIPTION
President and Chancellor Claims:
![2019-02-06_22-41-53](https://user-images.githubusercontent.com/19434157/52391226-c8c41a00-2a61-11e9-916d-c7d18584e9dd.gif) 

President and Peek 3 Cards Claim: 
![2019-02-06_22-44-48](https://user-images.githubusercontent.com/19434157/52391221-c19d0c00-2a61-11e9-83c0-2fca85b5e524.gif)

New Claim Button:
![image](https://user-images.githubusercontent.com/19434157/52392660-80f4c100-2a68-11e9-94c9-d4808c70fa54.png)

**This PR:**
All tests pass
![image](https://user-images.githubusercontent.com/19434157/52391236-d4afdc00-2a61-11e9-8bee-6405c6e01a7a.png)


✅ President can claim from the chat window
✅ Chancellor can claim from the chat window
✅ President can claim deck peek from the chat window
✅ Claiming from the chat window properly removes the claim button
✅ Claiming from the chat window maintains the order of cards as input
✅ Can claim investigation powers
✅ Can claim single policy peeks
✅ Fixes Single Policy Peek Blur Bug
✅ Fully resolves #1201
❌ Does not fix the blur bug when you die with the claim window open, still figuring that one out (its pretty rare though, and claiming from chat should reduce that anyway)