### PR TITLE
Removes Stickler CI in favor of running lint in Travis

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,0 @@
-linters:
-  eslint:
-    config: './eslintrc'
-files:
-  ignore:
-    - './node_modules'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: node_js
 node_js:
-  - "stable"
+  - 'stable'
 cache:
   directories:
-  - node_modules
+    - node_modules
 install:
   - yarn
 script:
   - yarn test
+  - yarn lint

--- a/routes/socket/user-requests.js
+++ b/routes/socket/user-requests.js
@@ -149,7 +149,6 @@ module.exports.sendUserGameSettings = socket => {
 						gameId: null
 					}
 				};
-				
 
 				userListInfo[`winsSeason${CURRENTSEASONNUMBER}`] = account[`winsSeason${CURRENTSEASONNUMBER}`];
 				userListInfo[`lossesSeason${CURRENTSEASONNUMBER}`] = account[`lossesSeason${CURRENTSEASONNUMBER}`];


### PR DESCRIPTION
This is what Travis looks like now:
![image](https://user-images.githubusercontent.com/19434157/52836547-a8730b80-30b0-11e9-92a1-23bea5711662.png)


Stickler CI kinda sucks. 

Added `yarn lint` to Travis instead. 

At this point, you can remove Stickler CI as an authorized app on this repo @cozuya.