### PR TITLE
Multiple Fixes to AEM Spectators

### DIFF
--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -2077,7 +2077,6 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 				return 'admin';
 			}
 		})();
-		console.log(data);
 		game.chats.push(data);
 
 		if (game.gameState.isTracksFlipped) {

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -1680,7 +1680,7 @@ module.exports.handleUpdatedRemakeGame = (passport, game, data) => {
  */
 module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserNames, editorUserNames, adminUserNames, addNewClaim) => {
 	// Authentication Assured in routes.js
-	if (!game || !game.general || game.general.disableChat || !data.chat) return;
+	if (!game || !game.general || !data.chat) return;
 	const chat = data.chat.trim();
 	const staffUserNames = [...modUserNames, ...editorUserNames, ...adminUserNames];
 	const playerIndex = game.publicPlayersState.findIndex(player => player.userName === passport.user);
@@ -1694,9 +1694,12 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 
 	const user = userList.find(u => passport.user === u.userName);
 
-	if (!user || !user.userName || game.general.disableChat) {
+	if (!user || !user.userName) {
 		return;
 	}
+	const AEM = staffUserNames.includes(passport.user) || newStaff.modUserNames.includes(passport.user) || newStaff.editorUserNames.includes(passport.user);
+
+	if (!AEM && game.general.disableChat) return;
 
 	data.userName = passport.user;
 
@@ -1785,7 +1788,6 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 		}
 	}
 
-	const AEM = staffUserNames.includes(passport.user) || newStaff.modUserNames.includes(passport.user) || newStaff.editorUserNames.includes(passport.user);
 	if (!AEM) {
 		if (player) {
 			if ((player.isDead && !game.gameState.isCompleted) || player.leftGame) {
@@ -2075,6 +2077,7 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 				return 'admin';
 			}
 		})();
+		console.log(data);
 		game.chats.push(data);
 
 		if (game.gameState.isTracksFlipped) {

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -368,17 +368,10 @@ class Gamechat extends React.Component {
 				};
 			}
 
-			if (gameInfo.general.disableChat) {
+			if (gameInfo.general.disableChat && !isStaff) {
 				return {
 					isDisabled: true,
 					placeholder: 'Chat disabled'
-				};
-			}
-
-			if (gameInfo.general.disableChat && isStaff) {
-				return {
-					isDisabled: false,
-					placeholder: 'Send a staff message'
 				};
 			}
 		} else {
@@ -389,7 +382,7 @@ class Gamechat extends React.Component {
 				};
 			}
 
-			if ((gameInfo.general.disableObserver || gameInfo.general.private) && isStaff) {
+			if ((gameInfo.general.disableObserver || gameInfo.general.private || gameInfo.general.disableChat) && isStaff) {
 				return {
 					isDisabled: false,
 					placeholder: 'Send a staff message'

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -564,12 +564,36 @@ class Gamechat extends React.Component {
 										: PLAYERCOLORS(playerListPlayer, !(gameSettings && gameSettings.disableSeasonal), 'chat-user')
 								}
 							>
-								{isSeated
-									? isBlind
-										? `${
-												gameInfo.general.replacementNames[gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName)]
-										  } {${gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName) + 1}}`
-										: `${chat.userName} {${gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName) + 1}}`
+								{isSeated ? (
+									''
+								) : chat.staffRole === 'moderator' ? (
+									<span data-tooltip="Moderator" data-inverted>
+										<span className="observer-chat">(Observer) </span>
+										<span className="moderator-name">(M) </span>
+									</span>
+								) : chat.staffRole === 'editor' ? (
+									<span data-tooltip="Editor" data-inverted>
+										<span className="observer-chat">(Observer) </span>
+										<span className="editor-name">(E) </span>
+									</span>
+								) : chat.staffRole === 'admin' ? (
+									<span data-tooltip="Admin" data-inverted>
+										<span className="observer-chat">(Observer) </span>
+										<span className="admin-name">(A) </span>
+									</span>
+								) : (
+									<span className="observer-chat">(Observer) </span>
+								)}
+								{gameInfo.gameState.isTracksFlipped
+									? isSeated
+										? isBlind
+											? `${
+													gameInfo.general.replacementNames[gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName)]
+											  } {${gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName) + 1}}`
+											: `${chat.userName} {${gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName) + 1}}`
+										: chat.userName
+									: isBlind
+									? '?'
 									: chat.userName}
 								{': '}
 							</span>

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -603,7 +603,6 @@ class Gamechat extends React.Component {
 						</div>
 					)
 				);
-				console.log(acc);
 				return acc;
 			}, []);
 		}

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -560,7 +560,9 @@ class Gamechat extends React.Component {
 							<span
 								className={
 									!playerListPlayer || (gameSettings && gameSettings.disablePlayerColorsInChat) || isBlind
-										? 'chat-user'
+										? isMod && (!isBlind || !isSeated)
+											? PLAYERCOLORS(playerListPlayer, !(gameSettings && gameSettings.disableSeasonal), 'chat-user')
+											: 'chat-user'
 										: PLAYERCOLORS(playerListPlayer, !(gameSettings && gameSettings.disableSeasonal), 'chat-user')
 								}
 							>
@@ -592,7 +594,7 @@ class Gamechat extends React.Component {
 											  } {${gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName) + 1}}`
 											: `${chat.userName} {${gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName) + 1}}`
 										: chat.userName
-									: isBlind
+									: isBlind && isSeated
 									? '?'
 									: chat.userName}
 								{': '}
@@ -601,7 +603,7 @@ class Gamechat extends React.Component {
 						</div>
 					)
 				);
-
+				console.log(acc);
 				return acc;
 			}, []);
 		}


### PR DESCRIPTION
Fixes #736 
Fixes #1295 

✅ Fixes a bug I introduced in a different PR (shocking I know)
    - No Prefixes were being added to chats `(AEM)`, `(Observer)`
✅ Mods now appear their correct name when spectating a blind game
✅ Mods now appear their correct color when spectating a blind game
✅ Mods can now send staff messages in silent games
