### PR TITLE
Allows AEM to freeze active games and prevent user actions

### DIFF
--- a/docs/model-info.txt
+++ b/docs/model-info.txt
@@ -3,6 +3,7 @@ gameState
 	isCompleted bool
 	isVetoEnabled bool
 	isTracksFlipped bool
+	isGameFrozen bool
 	pendingChancellorIndex number 
 	timedModeEnabled bool
 	phase string ?
@@ -103,6 +104,8 @@ private
 	unSeatedGameChats array
 		chat string
 		timestamp time
+	votesPeeked
+	gameFrozen
 	seatedPlayers array 5-10
 		userName string
 		connected bool

--- a/routes/socket/game/election-util.js
+++ b/routes/socket/game/election-util.js
@@ -192,7 +192,7 @@ module.exports.selectChancellor = (socket, passport, game, data) => {
 								game.gameState.timedModeEnabled = false;
 								const { selectVoting } = require('./election');
 								unvotedPlayerNames.forEach(userName => {
-									selectVoting({ user: userName }, game, { vote: Boolean(Math.random() > 0.5) });
+									selectVoting({ user: userName }, game, { vote: Boolean(Math.random() > 0.5) }, socket);
 								});
 							}
 						},

--- a/routes/socket/game/election-util.js
+++ b/routes/socket/game/election-util.js
@@ -12,6 +12,7 @@ module.exports.selectChancellor = (socket, passport, game, data) => {
 	}
 
 	if (game.gameState.isGameFrozen) {
+		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		return;
 	}
 

--- a/routes/socket/game/election-util.js
+++ b/routes/socket/game/election-util.js
@@ -11,6 +11,10 @@ module.exports.selectChancellor = (socket, passport, game, data) => {
 		return;
 	}
 
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
+
 	const { chancellorIndex } = data;
 	const { presidentIndex } = game.gameState;
 	const { experiencedMode } = game.general;

--- a/routes/socket/game/election-util.js
+++ b/routes/socket/game/election-util.js
@@ -12,7 +12,11 @@ module.exports.selectChancellor = (socket, passport, game, data) => {
 	}
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 

--- a/routes/socket/game/election-util.js
+++ b/routes/socket/game/election-util.js
@@ -13,9 +13,9 @@ module.exports.selectChancellor = (socket, passport, game, data, force = false) 
 	}
 
 	if (game.gameState.isGameFrozen && !force) {
-		try {
+		if (socket) {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {}
+		}
 		return;
 	}
 

--- a/routes/socket/game/election-util.js
+++ b/routes/socket/game/election-util.js
@@ -13,7 +13,9 @@ module.exports.selectChancellor = (socket, passport, game, data, force = false) 
 	}
 
 	if (game.gameState.isGameFrozen && !force) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {}
 		return;
 	}
 

--- a/routes/socket/game/election-util.js
+++ b/routes/socket/game/election-util.js
@@ -5,18 +5,15 @@ const { sendInProgressGameUpdate } = require('../util');
  * @param {object} passport - socket authentication.
  * @param {object} game - verifyed target game.
  * @param {object} data - from socket emit.
+ * @param {bool} force - whether or not this action was forced.
  */
-module.exports.selectChancellor = (socket, passport, game, data) => {
+module.exports.selectChancellor = (socket, passport, game, data, force = false) => {
 	if ((game.general.isTourny && game.general.tournyInfo.isCancelled) || data.chancellorIndex >= game.general.playerCount || data.chancellorIndex < 0) {
 		return;
 	}
 
-	if (game.gameState.isGameFrozen) {
-		try {
-			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
-			console.error(error);
-		}
+	if (game.gameState.isGameFrozen && !force) {
+		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		return;
 	}
 

--- a/routes/socket/game/election.js
+++ b/routes/socket/game/election.js
@@ -306,7 +306,11 @@ const selectPresidentVoteOnVeto = (passport, game, data, socket) => {
 	const publicPresident = game.publicPlayersState[game.gameState.presidentIndex];
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 
@@ -465,7 +469,11 @@ const selectChancellorVoteOnVeto = (passport, game, data, socket) => {
 	const publicChancellor = game.publicPlayersState[chancellorIndex];
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 
@@ -651,7 +659,11 @@ const selectChancellorPolicy = (passport, game, data, wasTimer, socket) => {
 	const enactedPolicy = game.private.currentChancellorOptions[data.selection === 3 ? 1 : 0];
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 
@@ -855,7 +867,11 @@ const selectPresidentPolicy = (passport, game, data, wasTimer, socket) => {
 	const nonDiscardedPolicies = _.range(0, 3).filter(num => num !== data.selection);
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 
@@ -1098,7 +1114,11 @@ module.exports.selectVoting = (passport, game, data, socket) => {
 	const playerIndex = seatedPlayers.findIndex(play => play.userName === passport.user);
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 

--- a/routes/socket/game/election.js
+++ b/routes/socket/game/election.js
@@ -655,6 +655,9 @@ const selectChancellorPolicy = (passport, game, data, wasTimer, socket) => {
 	const enactedPolicy = game.private.currentChancellorOptions[data.selection === 3 ? 1 : 0];
 
 	if (game.gameState.isGameFrozen) {
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {}
 		return;
 	}
 
@@ -858,6 +861,9 @@ const selectPresidentPolicy = (passport, game, data, wasTimer, socket) => {
 	const nonDiscardedPolicies = _.range(0, 3).filter(num => num !== data.selection);
 
 	if (game.gameState.isGameFrozen) {
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {}
 		return;
 	}
 

--- a/routes/socket/game/election.js
+++ b/routes/socket/game/election.js
@@ -308,8 +308,7 @@ const selectPresidentVoteOnVeto = (passport, game, data, socket) => {
 	if (game.gameState.isGameFrozen) {
 		try {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
-		}
+		} catch (error) {}
 		return;
 	}
 
@@ -470,8 +469,7 @@ const selectChancellorVoteOnVeto = (passport, game, data, socket) => {
 	if (game.gameState.isGameFrozen) {
 		try {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
-		}
+		} catch (error) {}
 		return;
 	}
 
@@ -1103,7 +1101,9 @@ module.exports.selectVoting = (passport, game, data, socket, force = false) => {
 	const playerIndex = seatedPlayers.findIndex(play => play.userName === passport.user);
 
 	if (game.gameState.isGameFrozen && !force) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {}
 		return;
 	}
 

--- a/routes/socket/game/election.js
+++ b/routes/socket/game/election.js
@@ -309,7 +309,6 @@ const selectPresidentVoteOnVeto = (passport, game, data, socket) => {
 		try {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		} catch (error) {
-			console.error(error);
 		}
 		return;
 	}
@@ -472,7 +471,6 @@ const selectChancellorVoteOnVeto = (passport, game, data, socket) => {
 		try {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		} catch (error) {
-			console.error(error);
 		}
 		return;
 	}
@@ -659,11 +657,6 @@ const selectChancellorPolicy = (passport, game, data, wasTimer, socket) => {
 	const enactedPolicy = game.private.currentChancellorOptions[data.selection === 3 ? 1 : 0];
 
 	if (game.gameState.isGameFrozen) {
-		try {
-			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
-			console.error(error);
-		}
 		return;
 	}
 
@@ -867,11 +860,6 @@ const selectPresidentPolicy = (passport, game, data, wasTimer, socket) => {
 	const nonDiscardedPolicies = _.range(0, 3).filter(num => num !== data.selection);
 
 	if (game.gameState.isGameFrozen) {
-		try {
-			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
-			console.error(error);
-		}
 		return;
 	}
 
@@ -1106,19 +1094,16 @@ module.exports.selectPresidentPolicy = selectPresidentPolicy;
  * @param {object} game - target game.
  * @param {object} data from socket emit
  * @param {object} socket - socket
+ * @param {bool} force - if action was forced
  */
-module.exports.selectVoting = (passport, game, data, socket) => {
+module.exports.selectVoting = (passport, game, data, socket, force = false) => {
 	const { seatedPlayers } = game.private;
 	const { experiencedMode } = game.general;
 	const player = seatedPlayers.find(player => player.userName === passport.user);
 	const playerIndex = seatedPlayers.findIndex(play => play.userName === passport.user);
 
-	if (game.gameState.isGameFrozen) {
-		try {
-			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
-			console.error(error);
-		}
+	if (game.gameState.isGameFrozen && !force) {
+		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		return;
 	}
 

--- a/routes/socket/game/election.js
+++ b/routes/socket/game/election.js
@@ -306,9 +306,9 @@ const selectPresidentVoteOnVeto = (passport, game, data, socket) => {
 	const publicPresident = game.publicPlayersState[game.gameState.presidentIndex];
 
 	if (game.gameState.isGameFrozen) {
-		try {
+		if (socket) {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {}
+		}
 		return;
 	}
 
@@ -467,9 +467,9 @@ const selectChancellorVoteOnVeto = (passport, game, data, socket) => {
 	const publicChancellor = game.publicPlayersState[chancellorIndex];
 
 	if (game.gameState.isGameFrozen) {
-		try {
+		if (socket) {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {}
+		}
 		return;
 	}
 
@@ -861,9 +861,9 @@ const selectPresidentPolicy = (passport, game, data, wasTimer, socket) => {
 	const nonDiscardedPolicies = _.range(0, 3).filter(num => num !== data.selection);
 
 	if (game.gameState.isGameFrozen) {
-		try {
+		if (socket) {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {}
+		}
 		return;
 	}
 
@@ -1107,9 +1107,9 @@ module.exports.selectVoting = (passport, game, data, socket, force = false) => {
 	const playerIndex = seatedPlayers.findIndex(play => play.userName === passport.user);
 
 	if (game.gameState.isGameFrozen && !force) {
-		try {
+		if (socket) {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {}
+		}
 		return;
 	}
 

--- a/routes/socket/game/election.js
+++ b/routes/socket/game/election.js
@@ -59,6 +59,10 @@ const enactPolicy = (game, team) => {
 	const index = game.trackState.enactedPolicies.length;
 	const { experiencedMode } = game.general;
 
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
+
 	if (game.private.lock.selectChancellor) {
 		game.private.lock.selectChancellor = false;
 	}
@@ -303,6 +307,10 @@ const selectPresidentVoteOnVeto = (passport, game, data) => {
 	const publicChancellor = game.publicPlayersState[chancellorIndex];
 	const publicPresident = game.publicPlayersState[game.gameState.presidentIndex];
 
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
+
 	if (!president || president.userName !== passport.user) {
 		return;
 	}
@@ -455,6 +463,10 @@ const selectChancellorVoteOnVeto = (passport, game, data) => {
 	const chancellorIndex = game.publicPlayersState.findIndex(player => player.governmentStatus === 'isChancellor');
 	const chancellor = game.private.seatedPlayers.find(player => player.userName === game.private._chancellorPlayerName);
 	const publicChancellor = game.publicPlayersState[chancellorIndex];
+
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
 
 	if (!publicChancellor || !publicChancellor.userName || passport.user !== publicChancellor.userName) {
 		return;
@@ -635,6 +647,10 @@ const selectChancellorPolicy = (passport, game, data, wasTimer) => {
 	const chancellorIndex = game.publicPlayersState.findIndex(player => player.governmentStatus === 'isChancellor');
 	const chancellor = game.private.seatedPlayers[chancellorIndex];
 	const enactedPolicy = game.private.currentChancellorOptions[data.selection === 3 ? 1 : 0];
+
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
 
 	if (!chancellor || chancellor.userName !== passport.user) {
 		return;
@@ -833,6 +849,10 @@ const selectPresidentPolicy = (passport, game, data, wasTimer) => {
 	const chancellorIndex = game.publicPlayersState.findIndex(player => player.governmentStatus === 'isChancellor');
 	const chancellor = game.private.seatedPlayers[chancellorIndex];
 	const nonDiscardedPolicies = _.range(0, 3).filter(num => num !== data.selection);
+
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
 
 	if (!president || president.userName !== passport.user || nonDiscardedPolicies.length !== 2) {
 		return;
@@ -1070,6 +1090,11 @@ module.exports.selectVoting = (passport, game, data) => {
 	const { experiencedMode } = game.general;
 	const player = seatedPlayers.find(player => player.userName === passport.user);
 	const playerIndex = seatedPlayers.findIndex(play => play.userName === passport.user);
+
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
+
 	const passedElection = () => {
 		const { gameState } = game;
 		const { presidentIndex } = gameState;

--- a/routes/socket/game/election.js
+++ b/routes/socket/game/election.js
@@ -655,9 +655,9 @@ const selectChancellorPolicy = (passport, game, data, wasTimer, socket) => {
 	const enactedPolicy = game.private.currentChancellorOptions[data.selection === 3 ? 1 : 0];
 
 	if (game.gameState.isGameFrozen) {
-		try {
+		if (socket) {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {}
+		}
 		return;
 	}
 

--- a/routes/socket/game/policy-powers.js
+++ b/routes/socket/game/policy-powers.js
@@ -11,6 +11,10 @@ module.exports.policyPeek = game => {
 	const { presidentIndex } = game.gameState;
 	const president = seatedPlayers[presidentIndex];
 
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
+
 	if (!game.private.lock.policyPeek && !(game.general.isTourny && game.general.tournyInfo.isCancelled)) {
 		game.private.lock.policyPeek = true;
 
@@ -34,6 +38,10 @@ module.exports.selectPolicies = (passport, game) => {
 	const { experiencedMode } = game.general;
 	const { seatedPlayers } = game.private;
 	const president = seatedPlayers[presidentIndex];
+
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
 
 	if (!president || president.userName !== passport.user) {
 		return;
@@ -198,6 +206,10 @@ module.exports.policyPeekAndDrop = game => {
 	const { presidentIndex } = game.gameState;
 	const president = seatedPlayers[presidentIndex];
 
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
+
 	if (!game.private.lock.policyPeekAndDrop && !(game.general.isTourny && game.general.tournyInfo.isCancelled)) {
 		game.private.lock.policyPeekAndDrop = true;
 
@@ -221,6 +233,10 @@ module.exports.selectOnePolicy = (passport, game) => {
 	const { experiencedMode } = game.general;
 	const { seatedPlayers } = game.private;
 	const president = seatedPlayers[presidentIndex];
+
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
 
 	if (!president || president.userName !== passport.user) {
 		return;
@@ -423,6 +439,10 @@ module.exports.selectBurnCard = (passport, game, data) => {
 		game.gameState.timedModeEnabled = game.private.timerId = null;
 	}
 
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
+
 	const { experiencedMode } = game.general;
 	const { presidentIndex } = game.gameState;
 	const { seatedPlayers } = game.private;
@@ -519,6 +539,10 @@ module.exports.investigateLoyalty = game => {
 	const { presidentIndex } = game.gameState;
 	const president = seatedPlayers[presidentIndex];
 
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
+
 	president.playersState.forEach((player, i) => {
 		if (!seatedPlayers[i]) {
 			console.error(`PLAYERSTATE CONTAINS NULL!\n${JSON.stringify(president.playersState)}\n${JSON.stringify(game)}`);
@@ -581,6 +605,10 @@ module.exports.selectPartyMembershipInvestigate = (passport, game, data) => {
 	if (game.general.timedMode && game.private.timerId) {
 		clearTimeout(game.private.timerId);
 		game.gameState.timedModeEnabled = game.private.timerId = null;
+	}
+
+	if (game.gameState.isGameFrozen) {
+		return;
 	}
 
 	const { playerIndex } = data;
@@ -744,6 +772,10 @@ module.exports.showPlayerLoyalty = game => {
 	const { presidentIndex } = game.gameState;
 	const president = seatedPlayers[presidentIndex];
 
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
+
 	if (!game.private.lock.showPlayerLoyalty && !(game.general.isTourny && game.general.tournyInfo.isCancelled)) {
 		game.private.lock.showPlayerLoyalty = true;
 
@@ -772,6 +804,10 @@ module.exports.selectPartyMembershipInvestigateReverse = (passport, game, data) 
 	if (game.general.timedMode && game.private.timerId) {
 		clearTimeout(game.private.timerId);
 		game.gameState.timedModeEnabled = game.private.timerId = null;
+	}
+
+	if (game.gameState.isGameFrozen) {
+		return;
 	}
 
 	const { playerIndex } = data;
@@ -952,6 +988,10 @@ module.exports.specialElection = game => {
 	const { presidentIndex } = game.gameState;
 	const president = seatedPlayers[presidentIndex];
 
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
+
 	if (!game.private.lock.specialElection && !(game.general.isTourny && game.general.tournyInfo.isCancelled)) {
 		game.private.lock.specialElection = true;
 		game.general.status = 'President to select special election.';
@@ -983,6 +1023,10 @@ module.exports.selectSpecialElection = (passport, game, data) => {
 	const { presidentIndex } = game.gameState;
 	const president = game.private.seatedPlayers[presidentIndex];
 	if (!president || president.userName !== passport.user) {
+		return;
+	}
+
+	if (game.gameState.isGameFrozen) {
 		return;
 	}
 
@@ -1019,6 +1063,10 @@ module.exports.executePlayer = game => {
 	const { seatedPlayers } = game.private;
 	const { presidentIndex } = game.gameState;
 	const president = seatedPlayers[presidentIndex];
+
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
 
 	if (!game.private.lock.executePlayer && !(game.general.isTourny && game.general.tournyInfo.isCancelled)) {
 		game.private.lock.executePlayer = true;
@@ -1070,6 +1118,10 @@ module.exports.selectPlayerToExecute = (passport, game, data) => {
 	const selectedPlayer = seatedPlayers[playerIndex];
 	const publicSelectedPlayer = game.publicPlayersState[playerIndex];
 	const president = seatedPlayers[presidentIndex];
+
+	if (game.gameState.isGameFrozen) {
+		return;
+	}
 
 	// Make sure the target is valid
 	if (playerIndex === presidentIndex || selectedPlayer.isDead || (selectedPlayer.role.cardName === 'hitler' && president.role.cardName === 'fascist')) {

--- a/routes/socket/game/policy-powers.js
+++ b/routes/socket/game/policy-powers.js
@@ -11,10 +11,6 @@ module.exports.policyPeek = game => {
 	const { presidentIndex } = game.gameState;
 	const president = seatedPlayers[presidentIndex];
 
-	if (game.gameState.isGameFrozen) {
-		return;
-	}
-
 	if (!game.private.lock.policyPeek && !(game.general.isTourny && game.general.tournyInfo.isCancelled)) {
 		game.private.lock.policyPeek = true;
 
@@ -32,14 +28,16 @@ module.exports.policyPeek = game => {
 /**
  * @param {object} passport - socket authentication.
  * @param {object} game - target game.
+ * @param {object} socket - socket
  */
-module.exports.selectPolicies = (passport, game) => {
+module.exports.selectPolicies = (passport, game, socket) => {
 	const { presidentIndex } = game.gameState;
 	const { experiencedMode } = game.general;
 	const { seatedPlayers } = game.private;
 	const president = seatedPlayers[presidentIndex];
 
 	if (game.gameState.isGameFrozen) {
+		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		return;
 	}
 
@@ -206,10 +204,6 @@ module.exports.policyPeekAndDrop = game => {
 	const { presidentIndex } = game.gameState;
 	const president = seatedPlayers[presidentIndex];
 
-	if (game.gameState.isGameFrozen) {
-		return;
-	}
-
 	if (!game.private.lock.policyPeekAndDrop && !(game.general.isTourny && game.general.tournyInfo.isCancelled)) {
 		game.private.lock.policyPeekAndDrop = true;
 
@@ -235,6 +229,7 @@ module.exports.selectOnePolicy = (passport, game) => {
 	const president = seatedPlayers[presidentIndex];
 
 	if (game.gameState.isGameFrozen) {
+		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		return;
 	}
 
@@ -432,14 +427,16 @@ module.exports.selectOnePolicy = (passport, game) => {
  * @param {object} passport - socket authentication.
  * @param {object} game - target game.
  * @param {object} data from socket emit
+ * @param {object} socket - socket
  */
-module.exports.selectBurnCard = (passport, game, data) => {
+module.exports.selectBurnCard = (passport, game, data, socket) => {
 	if (game.general.timedMode && game.private.timerId) {
 		clearTimeout(game.private.timerId);
 		game.gameState.timedModeEnabled = game.private.timerId = null;
 	}
 
 	if (game.gameState.isGameFrozen) {
+		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		return;
 	}
 
@@ -539,10 +536,6 @@ module.exports.investigateLoyalty = game => {
 	const { presidentIndex } = game.gameState;
 	const president = seatedPlayers[presidentIndex];
 
-	if (game.gameState.isGameFrozen) {
-		return;
-	}
-
 	president.playersState.forEach((player, i) => {
 		if (!seatedPlayers[i]) {
 			console.error(`PLAYERSTATE CONTAINS NULL!\n${JSON.stringify(president.playersState)}\n${JSON.stringify(game)}`);
@@ -600,14 +593,16 @@ module.exports.investigateLoyalty = game => {
  * @param {object} passport - socket authentication.
  * @param {object} game - target game.
  * @param {object} data from socket emit
+ * @param {object} socket - socket
  */
-module.exports.selectPartyMembershipInvestigate = (passport, game, data) => {
+module.exports.selectPartyMembershipInvestigate = (passport, game, data, socket) => {
 	if (game.general.timedMode && game.private.timerId) {
 		clearTimeout(game.private.timerId);
 		game.gameState.timedModeEnabled = game.private.timerId = null;
 	}
 
 	if (game.gameState.isGameFrozen) {
+		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		return;
 	}
 
@@ -772,10 +767,6 @@ module.exports.showPlayerLoyalty = game => {
 	const { presidentIndex } = game.gameState;
 	const president = seatedPlayers[presidentIndex];
 
-	if (game.gameState.isGameFrozen) {
-		return;
-	}
-
 	if (!game.private.lock.showPlayerLoyalty && !(game.general.isTourny && game.general.tournyInfo.isCancelled)) {
 		game.private.lock.showPlayerLoyalty = true;
 
@@ -799,14 +790,16 @@ module.exports.showPlayerLoyalty = game => {
  * @param {object} passport - socket authentication.
  * @param {object} game - target game.
  * @param {object} data from socket emit
+ * @param {object} socket - socket
  */
-module.exports.selectPartyMembershipInvestigateReverse = (passport, game, data) => {
+module.exports.selectPartyMembershipInvestigateReverse = (passport, game, data, socket) => {
 	if (game.general.timedMode && game.private.timerId) {
 		clearTimeout(game.private.timerId);
 		game.gameState.timedModeEnabled = game.private.timerId = null;
 	}
 
 	if (game.gameState.isGameFrozen) {
+		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		return;
 	}
 
@@ -988,10 +981,6 @@ module.exports.specialElection = game => {
 	const { presidentIndex } = game.gameState;
 	const president = seatedPlayers[presidentIndex];
 
-	if (game.gameState.isGameFrozen) {
-		return;
-	}
-
 	if (!game.private.lock.specialElection && !(game.general.isTourny && game.general.tournyInfo.isCancelled)) {
 		game.private.lock.specialElection = true;
 		game.general.status = 'President to select special election.';
@@ -1017,8 +1006,9 @@ module.exports.specialElection = game => {
  * @param {object} passport - socket authentication.
  * @param {object} game - target game.
  * @param {object} data from socket emit
+ * @param {object} socket - socket
  */
-module.exports.selectSpecialElection = (passport, game, data) => {
+module.exports.selectSpecialElection = (passport, game, data, socket) => {
 	const { playerIndex } = data;
 	const { presidentIndex } = game.gameState;
 	const president = game.private.seatedPlayers[presidentIndex];
@@ -1027,6 +1017,7 @@ module.exports.selectSpecialElection = (passport, game, data) => {
 	}
 
 	if (game.gameState.isGameFrozen) {
+		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		return;
 	}
 
@@ -1063,10 +1054,6 @@ module.exports.executePlayer = game => {
 	const { seatedPlayers } = game.private;
 	const { presidentIndex } = game.gameState;
 	const president = seatedPlayers[presidentIndex];
-
-	if (game.gameState.isGameFrozen) {
-		return;
-	}
 
 	if (!game.private.lock.executePlayer && !(game.general.isTourny && game.general.tournyInfo.isCancelled)) {
 		game.private.lock.executePlayer = true;
@@ -1110,8 +1097,9 @@ module.exports.executePlayer = game => {
  * @param {object} passport - socket authentication.
  * @param {object} game - target game.
  * @param {object} data from socket emit
+ * @param {object} socket - socket
  */
-module.exports.selectPlayerToExecute = (passport, game, data) => {
+module.exports.selectPlayerToExecute = (passport, game, data, socket, socket) => {
 	const { playerIndex } = data;
 	const { presidentIndex } = game.gameState;
 	const { seatedPlayers } = game.private;
@@ -1120,6 +1108,7 @@ module.exports.selectPlayerToExecute = (passport, game, data) => {
 	const president = seatedPlayers[presidentIndex];
 
 	if (game.gameState.isGameFrozen) {
+		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		return;
 	}
 

--- a/routes/socket/game/policy-powers.js
+++ b/routes/socket/game/policy-powers.js
@@ -605,9 +605,8 @@ module.exports.selectPartyMembershipInvestigate = (passport, game, data, socket)
 	}
 
 	if (game.gameState.isGameFrozen) {
-		try {
+		if (socket) {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
 		}
 		return;
 	}

--- a/routes/socket/game/policy-powers.js
+++ b/routes/socket/game/policy-powers.js
@@ -37,11 +37,6 @@ module.exports.selectPolicies = (passport, game, socket) => {
 	const president = seatedPlayers[presidentIndex];
 
 	if (game.gameState.isGameFrozen) {
-		try {
-			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
-			console.error(error);
-		}
 		return;
 	}
 
@@ -236,7 +231,6 @@ module.exports.selectOnePolicy = (passport, game) => {
 		try {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		} catch (error) {
-			console.error(error);
 		}
 		return;
 	}
@@ -447,7 +441,6 @@ module.exports.selectBurnCard = (passport, game, data, socket) => {
 		try {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		} catch (error) {
-			console.error(error);
 		}
 		return;
 	}
@@ -617,7 +610,6 @@ module.exports.selectPartyMembershipInvestigate = (passport, game, data, socket)
 		try {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		} catch (error) {
-			console.error(error);
 		}
 		return;
 	}
@@ -818,7 +810,6 @@ module.exports.selectPartyMembershipInvestigateReverse = (passport, game, data, 
 		try {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		} catch (error) {
-			console.error(error);
 		}
 		return;
 	}
@@ -1040,7 +1031,6 @@ module.exports.selectSpecialElection = (passport, game, data, socket) => {
 		try {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		} catch (error) {
-			console.error(error);
 		}
 		return;
 	}
@@ -1135,7 +1125,6 @@ module.exports.selectPlayerToExecute = (passport, game, data, socket) => {
 		try {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		} catch (error) {
-			console.error(error);
 		}
 		return;
 	}

--- a/routes/socket/game/policy-powers.js
+++ b/routes/socket/game/policy-powers.js
@@ -228,9 +228,8 @@ module.exports.selectOnePolicy = (passport, game) => {
 	const president = seatedPlayers[presidentIndex];
 
 	if (game.gameState.isGameFrozen) {
-		try {
+		if (socket) {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
 		}
 		return;
 	}
@@ -438,9 +437,8 @@ module.exports.selectBurnCard = (passport, game, data, socket) => {
 	}
 
 	if (game.gameState.isGameFrozen) {
-		try {
+		if (socket) {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
 		}
 		return;
 	}
@@ -807,9 +805,8 @@ module.exports.selectPartyMembershipInvestigateReverse = (passport, game, data, 
 	}
 
 	if (game.gameState.isGameFrozen) {
-		try {
+		if (socket) {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
 		}
 		return;
 	}
@@ -1028,9 +1025,8 @@ module.exports.selectSpecialElection = (passport, game, data, socket) => {
 	}
 
 	if (game.gameState.isGameFrozen) {
-		try {
+		if (socket) {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
 		}
 		return;
 	}
@@ -1122,9 +1118,8 @@ module.exports.selectPlayerToExecute = (passport, game, data, socket) => {
 	const president = seatedPlayers[presidentIndex];
 
 	if (game.gameState.isGameFrozen) {
-		try {
+		if (socket) {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
 		}
 		return;
 	}

--- a/routes/socket/game/policy-powers.js
+++ b/routes/socket/game/policy-powers.js
@@ -1099,7 +1099,7 @@ module.exports.executePlayer = game => {
  * @param {object} data from socket emit
  * @param {object} socket - socket
  */
-module.exports.selectPlayerToExecute = (passport, game, data, socket, socket) => {
+module.exports.selectPlayerToExecute = (passport, game, data, socket) => {
 	const { playerIndex } = data;
 	const { presidentIndex } = game.gameState;
 	const { seatedPlayers } = game.private;

--- a/routes/socket/game/policy-powers.js
+++ b/routes/socket/game/policy-powers.js
@@ -37,7 +37,11 @@ module.exports.selectPolicies = (passport, game, socket) => {
 	const president = seatedPlayers[presidentIndex];
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 
@@ -229,7 +233,11 @@ module.exports.selectOnePolicy = (passport, game) => {
 	const president = seatedPlayers[presidentIndex];
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 
@@ -436,7 +444,11 @@ module.exports.selectBurnCard = (passport, game, data, socket) => {
 	}
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 
@@ -602,7 +614,11 @@ module.exports.selectPartyMembershipInvestigate = (passport, game, data, socket)
 	}
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 
@@ -799,7 +815,11 @@ module.exports.selectPartyMembershipInvestigateReverse = (passport, game, data, 
 	}
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 
@@ -1017,7 +1037,11 @@ module.exports.selectSpecialElection = (passport, game, data, socket) => {
 	}
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 
@@ -1108,7 +1132,11 @@ module.exports.selectPlayerToExecute = (passport, game, data, socket) => {
 	const president = seatedPlayers[presidentIndex];
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 

--- a/routes/socket/routes.js
+++ b/routes/socket/routes.js
@@ -293,7 +293,7 @@ module.exports = (modUserNames, editorUserNames, adminUserNames, altmodUserNames
 			socket.on('updateRemake', data => {
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					handleUpdatedRemakeGame(passport, game, data);
+					handleUpdatedRemakeGame(passport, game, data, socket);
 				}
 			});
 			socket.on('updateBio', data => {

--- a/routes/socket/routes.js
+++ b/routes/socket/routes.js
@@ -19,6 +19,7 @@ const {
 	handleUpdatedPlayerNote,
 	handleSubscribeModChat,
 	handleModPeekVotes,
+	handleGameFreeze,
 	handleUpdateTyping,
 	handleHasSeenNewPlayerModal
 } = require('./user-events');
@@ -358,6 +359,17 @@ module.exports = (modUserNames, editorUserNames, adminUserNames, altmodUserNames
 					const game = findGame({ uid });
 					if (game && game.private && game.private.seatedPlayers) {
 						handleModPeekVotes(socket, passport, game, data.modName);
+					}
+				} else {
+					socket.emit('sendAlert', 'Game is missing.');
+				}
+			});
+			socket.on('modFreezeGame', data => {
+				const uid = data.uid;
+				if (authenticated && isAEM) {
+					const game = findGame({ uid });
+					if (game && game.private && game.private.seatedPlayers) {
+						handleGameFreeze(socket, passport, game, data.modName);
 					}
 				} else {
 					socket.emit('sendAlert', 'Game is missing.');

--- a/routes/socket/routes.js
+++ b/routes/socket/routes.js
@@ -395,35 +395,35 @@ module.exports = (modUserNames, editorUserNames, adminUserNames, altmodUserNames
 				if (isRestricted) return;
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					selectChancellor(socket, passport, game, data);
+					selectChancellor(socket, passport, game, data, socket);
 				}
 			});
 			socket.on('selectedVoting', data => {
 				if (isRestricted) return;
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					selectVoting(passport, game, data);
+					selectVoting(passport, game, data, socket);
 				}
 			});
 			socket.on('selectedPresidentPolicy', data => {
 				if (isRestricted) return;
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					selectPresidentPolicy(passport, game, data);
+					selectPresidentPolicy(passport, game, data, socket);
 				}
 			});
 			socket.on('selectedChancellorPolicy', data => {
 				if (isRestricted) return;
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					selectChancellorPolicy(passport, game, data);
+					selectChancellorPolicy(passport, game, data, socket);
 				}
 			});
 			socket.on('selectedPresidentVoteOnVeto', data => {
 				if (isRestricted) return;
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					selectPresidentVoteOnVeto(passport, game, data);
+					selectPresidentVoteOnVeto(passport, game, data, socket);
 				}
 			});
 			// policy-powers
@@ -431,14 +431,14 @@ module.exports = (modUserNames, editorUserNames, adminUserNames, altmodUserNames
 				if (isRestricted) return;
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					selectPartyMembershipInvestigate(passport, game, data);
+					selectPartyMembershipInvestigate(passport, game, data, socket);
 				}
 			});
 			socket.on('selectPartyMembershipInvestigateReverse', data => {
 				if (isRestricted) return;
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					selectPartyMembershipInvestigateReverse(passport, game, data);
+					selectPartyMembershipInvestigateReverse(passport, game, data, socket);
 				}
 			});
 			socket.on('selectedPolicies', data => {
@@ -446,28 +446,28 @@ module.exports = (modUserNames, editorUserNames, adminUserNames, altmodUserNames
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
 					if (game.private.lock.policyPeekAndDrop) selectOnePolicy(passport, game);
-					else selectPolicies(passport, game);
+					else selectPolicies(passport, game, socket);
 				}
 			});
 			socket.on('selectedPresidentVoteOnBurn', data => {
 				if (isRestricted) return;
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					selectBurnCard(passport, game, data);
+					selectBurnCard(passport, game, data, socket);
 				}
 			});
 			socket.on('selectedPlayerToExecute', data => {
 				if (isRestricted) return;
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					selectPlayerToExecute(passport, game, data);
+					selectPlayerToExecute(passport, game, data, socket);
 				}
 			});
 			socket.on('selectedSpecialElection', data => {
 				if (isRestricted) return;
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					selectSpecialElection(passport, game, data);
+					selectSpecialElection(passport, game, data, socket);
 				}
 			});
 		});

--- a/routes/socket/routes.js
+++ b/routes/socket/routes.js
@@ -395,7 +395,7 @@ module.exports = (modUserNames, editorUserNames, adminUserNames, altmodUserNames
 				if (isRestricted) return;
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					selectChancellor(socket, passport, game, data, socket);
+					selectChancellor(socket, passport, game, data);
 				}
 			});
 			socket.on('selectedVoting', data => {

--- a/routes/socket/routes.js
+++ b/routes/socket/routes.js
@@ -409,14 +409,14 @@ module.exports = (modUserNames, editorUserNames, adminUserNames, altmodUserNames
 				if (isRestricted) return;
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					selectPresidentPolicy(passport, game, data, socket);
+					selectPresidentPolicy(passport, game, data, false, socket);
 				}
 			});
 			socket.on('selectedChancellorPolicy', data => {
 				if (isRestricted) return;
 				const game = findGame(data);
 				if (authenticated && ensureInGame(passport, game)) {
-					selectChancellorPolicy(passport, game, data, socket);
+					selectChancellorPolicy(passport, game, data, false, socket);
 				}
 			});
 			socket.on('selectedPresidentVoteOnVeto', data => {

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -1387,13 +1387,15 @@ module.exports.handleAddNewClaim = (socket, passport, game, data) => {
  * @param {object} passport - socket authentication.
  * @param {object} game - target game.
  * @param {object} data - from socket emit.
+ * @param {object} socket - socket
  */
-module.exports.handleUpdatedRemakeGame = (passport, game, data) => {
+module.exports.handleUpdatedRemakeGame = (passport, game, data, socket) => {
 	if (game.general.isRemade) {
 		return; // Games can only be remade once.
 	}
 
 	if (game.gameState.isGameFrozen) {
+		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		return;
 	}
 

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -1397,8 +1397,7 @@ module.exports.handleUpdatedRemakeGame = (passport, game, data, socket) => {
 	if (game.gameState.isGameFrozen) {
 		try {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {
-		}
+		} catch (error) {}
 		return;
 	}
 

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -1863,7 +1863,7 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 				}
 				let vote = false;
 				if (voteString == 'ya' || voteString == 'ja' || voteString == 'yes' || voteString == 'true') vote = true;
-				game.private.unSeatedGameChats = [
+				game.private.unSeatedGameChats.push(
 					{
 						gameChat: true,
 						timestamp: new Date(),
@@ -1887,7 +1887,7 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 							}
 						]
 					}
-				];
+				);
 				selectVoting({ user: affectedPlayer.userName }, game, { vote }, true);
 				sendPlayerChatUpdate(game, data);
 			} else {
@@ -1933,7 +1933,7 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 					}
 					counter++;
 				}
-				game.private.unSeatedGameChats = [
+				game.private.unSeatedGameChats.push(
 					{
 						gameChat: true,
 						timestamp: new Date(),
@@ -1950,7 +1950,7 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 							}
 						]
 					}
-				];
+				);
 				selectChancellor(null, { user: affectedPlayer.userName }, game, { chancellorIndex: chancellor }, true);
 				setTimeout(() => {
 					for (let p of game.private.seatedPlayers.filter(player => !player.isDead)) {
@@ -1996,7 +1996,7 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 					socket.emit('sendAlert', `The player in seat ${chancellorPick} is not a valid chancellor. (Dead or TL)`);
 					return;
 				}
-				game.private.unSeatedGameChats = [
+				game.private.unSeatedGameChats.push(
 					{
 						gameChat: true,
 						timestamp: new Date(),
@@ -2020,7 +2020,7 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 							}
 						]
 					}
-				];
+				);
 				selectChancellor(null, { user: affectedPlayer.userName }, game, { chancellorIndex: chancellorPick - 1 }, true);
 				sendPlayerChatUpdate(game, data);
 			} else {

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -1395,9 +1395,9 @@ module.exports.handleUpdatedRemakeGame = (passport, game, data, socket) => {
 	}
 
 	if (game.gameState.isGameFrozen) {
-		try {
+		if (socket) {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
-		} catch (error) {}
+		}
 		return;
 	}
 

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -1398,7 +1398,6 @@ module.exports.handleUpdatedRemakeGame = (passport, game, data, socket) => {
 		try {
 			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
 		} catch (error) {
-			console.error(error);
 		}
 		return;
 	}
@@ -1889,7 +1888,7 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 						]
 					}
 				];
-				selectVoting({ user: affectedPlayer.userName }, game, { vote });
+				selectVoting({ user: affectedPlayer.userName }, game, { vote }, true);
 				sendPlayerChatUpdate(game, data);
 			} else {
 				socket.emit('sendAlert', 'The game has not started yet.');
@@ -1952,10 +1951,10 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 						]
 					}
 				];
-				selectChancellor(null, { user: affectedPlayer.userName }, game, { chancellorIndex: chancellor });
+				selectChancellor(null, { user: affectedPlayer.userName }, game, { chancellorIndex: chancellor }, true);
 				setTimeout(() => {
 					for (let p of game.private.seatedPlayers.filter(player => !player.isDead)) {
-						selectVoting({ user: p.userName }, game, { vote: false });
+						selectVoting({ user: p.userName }, game, { vote: false }, true);
 					}
 				}, 1000);
 				sendPlayerChatUpdate(game, data);
@@ -2022,7 +2021,7 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 						]
 					}
 				];
-				selectChancellor(null, { user: affectedPlayer.userName }, game, { chancellorIndex: chancellorPick - 1 });
+				selectChancellor(null, { user: affectedPlayer.userName }, game, { chancellorIndex: chancellorPick - 1 }, true);
 				sendPlayerChatUpdate(game, data);
 			} else {
 				socket.emit('sendAlert', 'The game has not started yet.');

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -1862,31 +1862,29 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 				}
 				let vote = false;
 				if (voteString == 'ya' || voteString == 'ja' || voteString == 'yes' || voteString == 'true') vote = true;
-				game.private.unSeatedGameChats.push(
-					{
-						gameChat: true,
-						timestamp: new Date(),
-						chat: [
-							{
-								text: 'An AEM member has forced '
-							},
-							{
-								text: `${affectedPlayer.userName} {${affectedPlayerNumber + 1}}`,
-								type: 'player'
-							},
-							{
-								text: ' to vote '
-							},
-							{
-								text: `${vote ? 'ja' : 'nein'}`,
-								type: 'player'
-							},
-							{
-								text: '.'
-							}
-						]
-					}
-				);
+				game.private.unSeatedGameChats.push({
+					gameChat: true,
+					timestamp: new Date(),
+					chat: [
+						{
+							text: 'An AEM member has forced '
+						},
+						{
+							text: `${affectedPlayer.userName} {${affectedPlayerNumber + 1}}`,
+							type: 'player'
+						},
+						{
+							text: ' to vote '
+						},
+						{
+							text: `${vote ? 'ja' : 'nein'}`,
+							type: 'player'
+						},
+						{
+							text: '.'
+						}
+					]
+				});
 				selectVoting({ user: affectedPlayer.userName }, game, { vote }, null, true);
 				sendPlayerChatUpdate(game, data);
 			} else {

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -1993,31 +1993,29 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 					socket.emit('sendAlert', `The player in seat ${chancellorPick} is not a valid chancellor. (Dead or TL)`);
 					return;
 				}
-				game.private.unSeatedGameChats.push(
-					{
-						gameChat: true,
-						timestamp: new Date(),
-						chat: [
-							{
-								text: 'An AEM member has forced '
-							},
-							{
-								text: `${affectedPlayer.userName} {${affectedPlayerNumber + 1}}`,
-								type: 'player'
-							},
-							{
-								text: ' to pick '
-							},
-							{
-								text: `${affectedChancellor.userName} {${chancellorPick}}`,
-								type: 'player'
-							},
-							{
-								text: ' as chancellor.'
-							}
-						]
-					}
-				);
+				game.private.unSeatedGameChats.push({
+					gameChat: true,
+					timestamp: new Date(),
+					chat: [
+						{
+							text: 'An AEM member has forced '
+						},
+						{
+							text: `${affectedPlayer.userName} {${affectedPlayerNumber + 1}}`,
+							type: 'player'
+						},
+						{
+							text: ' to pick '
+						},
+						{
+							text: `${affectedChancellor.userName} {${chancellorPick}}`,
+							type: 'player'
+						},
+						{
+							text: ' as chancellor.'
+						}
+					]
+				});
 				selectChancellor(null, { user: affectedPlayer.userName }, game, { chancellorIndex: chancellorPick - 1 }, true);
 				sendPlayerChatUpdate(game, data);
 			} else {

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -2315,7 +2315,7 @@ module.exports.handleGameFreeze = (socket, passport, game, modUserName) => {
 	if (gameToFreeze && gameToFreeze.private && gameToFreeze.private.seatedPlayers) {
 		for (player of gameToFreeze.private.seatedPlayers) {
 			if (modUserName === player.userName) {
-				socket.emit('sendAlert', 'You cannot peek votes whilst playing.');
+				socket.emit('sendAlert', 'You cannot freeze the game whilst playing.');
 				return;
 			}
 		}
@@ -2339,22 +2339,11 @@ module.exports.handleGameFreeze = (socket, passport, game, modUserName) => {
 
 	game.gameState.isGameFrozen = !game.gameState.isGameFrozen;
 
-	game.private.unSeatedGameChats.push({
-		gameChat: true,
-		timestamp: new Date(),
-		chat: [
-			{
-				text: 'AEM member '
-			},
-			{
-				text: modUserName,
-				type: 'player'
-			},
-			{
-				text: `has ${game.gameState.isGameFrozen ? 'frozen' : 'unfrozen'} the game.`
-			}
-		],
-		isBroadcast: true
+	gameToFreeze.chats.push({
+		userName: `(AEM) ${modUserName}`,
+		chat: `has ${game.gameState.isGameFrozen ? 'frozen' : 'unfrozen'} the game. ${game.gameState.isGameFrozen ? 'All actions are prevented.' : ''}`,
+		isBroadcast: true,
+		timestamp: new Date()
 	});
 
 	sendInProgressGameUpdate(game);

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -1684,8 +1684,8 @@ module.exports.handleUpdatedRemakeGame = (passport, game, data) => {
 			} (${remakePlayerCount}/${minimumRemakeVoteCount})`
 		});
 	}
+	socket.emit('updateRemakeStatus', player.isRemakeVoting);
 	game.chats.push(chat);
-
 	sendInProgressGameUpdate(game);
 };
 

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -1930,24 +1930,22 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 					}
 					counter++;
 				}
-				game.private.unSeatedGameChats.push(
-					{
-						gameChat: true,
-						timestamp: new Date(),
-						chat: [
-							{
-								text: 'An AEM member has force skipped the government with '
-							},
-							{
-								text: `${affectedPlayer.userName} {${affectedPlayerNumber + 1}}`,
-								type: 'player'
-							},
-							{
-								text: ' as president.'
-							}
-						]
-					}
-				);
+				game.private.unSeatedGameChats.push({
+					gameChat: true,
+					timestamp: new Date(),
+					chat: [
+						{
+							text: 'An AEM member has force skipped the government with '
+						},
+						{
+							text: `${affectedPlayer.userName} {${affectedPlayerNumber + 1}}`,
+							type: 'player'
+						},
+						{
+							text: ' as president.'
+						}
+					]
+				});
 				selectChancellor(null, { user: affectedPlayer.userName }, game, { chancellorIndex: chancellor }, true);
 				setTimeout(() => {
 					for (let p of game.private.seatedPlayers.filter(player => !player.isDead)) {

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -1888,7 +1888,7 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 						]
 					}
 				);
-				selectVoting({ user: affectedPlayer.userName }, game, { vote }, true);
+				selectVoting({ user: affectedPlayer.userName }, game, { vote }, null, true);
 				sendPlayerChatUpdate(game, data);
 			} else {
 				socket.emit('sendAlert', 'The game has not started yet.');
@@ -1954,7 +1954,7 @@ module.exports.handleAddNewGameChat = (socket, passport, data, game, modUserName
 				selectChancellor(null, { user: affectedPlayer.userName }, game, { chancellorIndex: chancellor }, true);
 				setTimeout(() => {
 					for (let p of game.private.seatedPlayers.filter(player => !player.isDead)) {
-						selectVoting({ user: p.userName }, game, { vote: false }, true);
+						selectVoting({ user: p.userName }, game, { vote: false }, null, true);
 					}
 				}, 1000);
 				sendPlayerChatUpdate(game, data);

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -2339,6 +2339,10 @@ module.exports.handleGameFreeze = (socket, passport, game, modUserName) => {
 	if (game.gameState.isGameFrozen) {
 		if (now - game.gameState.isGameFrozen >= 4000) {
 			game.gameState.isGameFrozen = false;
+		} else {
+			// Figured this would get annoying - can add it back if mods want.
+			// socket.emit('sendAlert', `You cannot do this yet, please wait ${Math.ceil((now - game.gameState.isGameFrozen) / 1000)} seconds`);
+			return;
 		}
 	} else {
 		game.gameState.isGameFrozen = now;

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -1395,7 +1395,11 @@ module.exports.handleUpdatedRemakeGame = (passport, game, data, socket) => {
 	}
 
 	if (game.gameState.isGameFrozen) {
-		socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		try {
+			socket.emit('sendAlert', 'An AEM member has prevented this game from proceeding. Please wait.');
+		} catch (error) {
+			console.error(error);
+		}
 		return;
 	}
 

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -2342,7 +2342,14 @@ module.exports.handleGameFreeze = (socket, passport, game, modUserName) => {
 		}
 	}
 
-	game.gameState.isGameFrozen = !game.gameState.isGameFrozen;
+	const now = new Date();
+	if (game.gameState.isGameFrozen) {
+		if (now - game.gameState.isGameFrozen >= 4000) {
+			game.gameState.isGameFrozen = false;
+		}
+	} else {
+		game.gameState.isGameFrozen = now;
+	}
 
 	gameToFreeze.chats.push({
 		userName: `(AEM) ${modUserName}`,

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -797,7 +797,7 @@ class Gamechat extends React.Component {
 					{!this.isPlayerInGame(gameInfo.publicPlayersState, userInfo.username) && isStaff && gameInfo && gameInfo.gameState && gameInfo.gameState.isStarted && (
 						<div>
 							<div className="ui button primary" onClick={() => modFreezeGame()} style={{ width: '60px' }}>
-								Freeze/Unfreeze
+								Freeze/<br/>Unfreeze
 							</div>
 						</div>
 					)}

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -728,6 +728,13 @@ class Gamechat extends React.Component {
 			});
 		};
 
+		const modFreezeGame = () => {
+			socket.emit('modFreezeGame', {
+				modName: userInfo.userName,
+				uid: gameInfo.general.uid
+			});
+		};
+
 		const sendModEndGame = winningTeamName => {
 			socket.emit('updateModAction', {
 				modName: userInfo.userName,
@@ -784,6 +791,13 @@ class Gamechat extends React.Component {
 						<div>
 							<div className="ui button primary" onClick={() => modGetCurrentVotes()} style={{ width: '60px' }}>
 								Peek Votes
+							</div>
+						</div>
+					)}
+					{!this.isPlayerInGame(gameInfo.publicPlayersState, userInfo.username) && isStaff && gameInfo && gameInfo.gameState && gameInfo.gameState.isStarted && (
+						<div>
+							<div className="ui button primary" onClick={() => modFreezeGame()} style={{ width: '60px' }}>
+								Freeze/Unfreeze
 							</div>
 						</div>
 					)}

--- a/src/frontend-scripts/components/section-main/Tracks.jsx
+++ b/src/frontend-scripts/components/section-main/Tracks.jsx
@@ -25,26 +25,28 @@ class Tracks extends React.Component {
 			});
 		}
 
-		this.props.socket.on('updateRemakeStatus', status => {
-			this.setState(
-				{
-					remakeStatus: status,
-					remakeStatusDisabled: true
-				},
-				() => {
-					setTimeout(
-						() => {
-							if (this._ismounted) {
-								this.setState({
-									remakeStatusDisabled: false
-								});
-							}
-						},
-						this.state.remakeStatus ? 2000 : 5000
-					);
-				}
-			);
-		});
+		if (this.props.socket) {
+			this.props.socket.on('updateRemakeStatus', status => {
+				this.setState(
+					{
+						remakeStatus: status,
+						remakeStatusDisabled: true
+					},
+					() => {
+						setTimeout(
+							() => {
+								if (this._ismounted) {
+									this.setState({
+										remakeStatusDisabled: false
+									});
+								}
+							},
+							this.state.remakeStatus ? 2000 : 5000
+						);
+					}
+				);
+			});
+		}
 	}
 
 	componentWillUnmount() {

--- a/src/frontend-scripts/components/section-main/Tracks.jsx
+++ b/src/frontend-scripts/components/section-main/Tracks.jsx
@@ -24,6 +24,27 @@ class Tracks extends React.Component {
 				new Notification(data);
 			});
 		}
+
+		this.props.socket.on('updateRemakeStatus', status => {
+			this.setState(
+				{
+					remakeStatus: status,
+					remakeStatusDisabled: true
+				},
+				() => {
+					setTimeout(
+						() => {
+							if (this._ismounted) {
+								this.setState({
+									remakeStatusDisabled: false
+								});
+							}
+						},
+						this.state.remakeStatus ? 10000 : 2000
+					);
+				}
+			);
+		});
 	}
 
 	componentWillUnmount() {
@@ -286,29 +307,10 @@ class Tracks extends React.Component {
 
 		const updateRemake = () => {
 			if (!this.state.remakeStatusDisabled) {
-				this.setState(
-					{
-						remakeStatus: !this.state.remakeStatus,
-						remakeStatusDisabled: true
-					},
-					() => {
-						this.props.socket.emit('updateRemake', {
-							remakeStatus: this.state.remakeStatus,
-							uid: gameInfo.general.uid
-						});
-					}
-				);
-
-				setTimeout(
-					() => {
-						if (this._ismounted) {
-							this.setState({
-								remakeStatusDisabled: false
-							});
-						}
-					},
-					this.state.remakeStatus ? 10000 : 2000
-				);
+				this.props.socket.emit('updateRemake', {
+					remakeStatus: !this.state.remakeStatus,
+					uid: gameInfo.general.uid
+				});
 			}
 		};
 

--- a/src/frontend-scripts/components/section-main/Tracks.jsx
+++ b/src/frontend-scripts/components/section-main/Tracks.jsx
@@ -40,7 +40,7 @@ class Tracks extends React.Component {
 								});
 							}
 						},
-						this.state.remakeStatus ? 10000 : 2000
+						this.state.remakeStatus ? 2000 : 5000
 					);
 				}
 			);


### PR DESCRIPTION
**Since Travis is Broken:** 
![image](https://user-images.githubusercontent.com/19434157/54015275-db0aa400-4144-11e9-822a-8e7d01c02498.png)

Mod Button:
![image](https://user-images.githubusercontent.com/19434157/54015513-8582c700-4145-11e9-89f7-0bc5ce014f36.png)
Initial Chat:
![image](https://user-images.githubusercontent.com/19434157/54015504-7e5bb900-4145-11e9-8f99-c6b7478bcb94.png)
When trying to do an action: 
![image](https://user-images.githubusercontent.com/19434157/54015523-8f0c2f00-4145-11e9-99ba-f8ad4ddea8bd.png)
Chat Messages: 
![image](https://user-images.githubusercontent.com/19434157/54015533-98959700-4145-11e9-98d1-5c66702e492f.png)
Mod Log: 
![image](https://user-images.githubusercontent.com/19434157/54015597-c7137200-4145-11e9-9d1a-b02b29751ead.png)



**The Following Actions have been tested to be prevented gracefully:** 
✅ Chancellor Selection
✅ Government Voting
✅ Investigation
✅ 3 Card Peek
✅ Bullet
✅ Peek and Drop
✅ Special Election
✅ Policy Enactment
✅ Veto Voting
✅ 1 Card Peek
✅ Show Loyalty
✅ Remake

**Note:** There is also a 4 second timeout for disabling the freeze, to prevent accidental double-clicks. 