### PR TITLE
Gamechat and Generalchat Improvements

### DIFF
--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -202,7 +202,7 @@ class Gamechat extends React.Component {
 
 		const { chatValue } = this.state;
 
-		if (currentValue.length < 300 && currentValue && !$('.expando-container + div').hasClass('disabled')) {
+		if (chatValue.length <= 300 && chatValue && !$('.expando-container + div').hasClass('disabled')) {
 			if (userInfo.gameSettings && !userInfo.gameSettings.disableTyping) {
 				updateIsTyping(true);
 			}
@@ -287,6 +287,10 @@ class Gamechat extends React.Component {
 	};
 
 	handleInsertEmote = emote => {
+		this.setState({
+			chatValue: this.state.chatValue + ' ' + emote
+		});
+		this.chatInput.focus();
 	};
 
 	renderModEndGameButtons() {
@@ -1030,6 +1034,22 @@ class Gamechat extends React.Component {
 								}}
 							>
 								The word "{this.state.badWord[1]}"{this.state.badWord[0] !== this.state.badWord[1] ? ` (${this.state.badWord[0]})` : ''} is forbidden.
+							</span>
+						)}
+						{this.state.chatValue.length > 300 && !this.state.badWord[0] && (
+							<span
+								style={{
+									zIndex: '-1',
+									position: 'absolute',
+									top: '-32px',
+									height: '40px',
+									backgroundColor: 'indianred',
+									padding: '7px',
+									borderRadius: '10px 10px 0px 0px',
+									border: '1px solid #8c8c8c'
+								}}
+							>
+								{`This message is too long ${300 - this.state.chatValue.length}`}
 							</span>
 						)}
 						<input

--- a/src/frontend-scripts/components/section-right/Generalchat.jsx
+++ b/src/frontend-scripts/components/section-right/Generalchat.jsx
@@ -95,7 +95,9 @@ export default class Generalchat extends React.Component {
 	handleSubmit = e => {
 		if (this.chatDisabled()) return;
 
-		if (inputValue && inputValue.length < 300) {
+		const { chatValue } = this.state;
+
+		if (chatValue && chatValue.length <= 300) {
 			this.props.socket.emit('addNewGeneralChat', {
 				chat: chatValue
 			});
@@ -152,6 +154,21 @@ export default class Generalchat extends React.Component {
 						}}
 					>
 						"{this.state.badWord[1]}"{this.state.badWord[0] !== this.state.badWord[1] ? ` (${this.state.badWord[0]})` : ''} is forbidden.
+					</span>
+				)}
+				{this.state.chatValue.length > 300 && !this.state.badWord[0] && (
+					<span
+						style={{
+							position: 'absolute',
+							top: '-22px',
+							height: '40px',
+							backgroundColor: 'indianred',
+							padding: '7px',
+							borderRadius: '10px 10px 0px 0px',
+							border: '1px solid #8c8c8c'
+						}}
+					>
+						{`This message is too long ${300 - this.state.chatValue.length}`}
 					</span>
 				)}
 				<textarea

--- a/src/frontend-scripts/components/section-right/Generalchat.jsx
+++ b/src/frontend-scripts/components/section-right/Generalchat.jsx
@@ -12,7 +12,8 @@ export default class Generalchat extends React.Component {
 		stickyEnabled: true,
 		badWord: [null, null],
 		textLastChanged: 0,
-		textChangeTimer: -1
+		textChangeTimer: -1,
+		chatValue: ''
 	};
 
 	componentDidMount() {
@@ -38,14 +39,6 @@ export default class Generalchat extends React.Component {
 		}
 	}
 
-	handleChatClearClick = () => {
-		this.setState({ inputValue: '' });
-	};
-
-	handleInputChange = e => {
-		this.setState({ inputValue: `${e.target.value}` });
-	};
-
 	renderPreviousSeasonAward(type) {
 		switch (type) {
 			case 'bronze':
@@ -70,8 +63,12 @@ export default class Generalchat extends React.Component {
 	handleTyping = e => {
 		e.preventDefault();
 
-		const text = this.chatInput.value;
-		const foundWord = getBadWord(text);
+		this.setState({
+			chatValue: e.target.value
+		});
+		const chatValue = e.target.value;
+
+		const foundWord = getBadWord(chatValue);
 		if (this.state.badWord[0] !== foundWord[0]) {
 			if (this.state.textChangeTimer !== -1) clearTimeout(this.state.textChangeTimer);
 			if (foundWord[0]) {
@@ -80,7 +77,7 @@ export default class Generalchat extends React.Component {
 					textLastChanged: Date.now(),
 					textChangeTimer: setTimeout(() => {
 						this.setState({ textChangeTimer: -1 });
-					}, 1100)
+					}, 2000)
 				});
 			} else {
 				this.setState({
@@ -97,24 +94,16 @@ export default class Generalchat extends React.Component {
 
 	handleSubmit = e => {
 		if (this.chatDisabled()) return;
-		const inputValue = this.chatInput.value;
 
 		if (inputValue && inputValue.length < 300) {
 			this.props.socket.emit('addNewGeneralChat', {
-				chat: inputValue
+				chat: chatValue
 			});
 
-			this.chatInput.value = '';
-			if (this.state.badWord[0]) {
-				this.setState({
-					badWord: [null, null]
-				});
-			}
-
-			this.chatInput.blur();
-			setTimeout(() => {
-				this.chatInput.focus();
-			}, 100);
+			this.setState({
+				chatValue: '',
+				badWord: [null, null]
+			});
 		}
 	};
 
@@ -170,7 +159,7 @@ export default class Generalchat extends React.Component {
 					disabled={!userInfo.userName || (userInfo.gameSettings && userInfo.gameSettings.isPrivate)}
 					className="chat-input-box"
 					placeholder="Send a message"
-					maxLength="300"
+					value={this.state.chatValue}
 					spellCheck="false"
 					onKeyDown={this.handleKeyPress}
 					onChange={this.handleTyping}

--- a/src/frontend-scripts/components/section-right/Generalchat.jsx
+++ b/src/frontend-scripts/components/section-right/Generalchat.jsx
@@ -125,7 +125,9 @@ export default class Generalchat extends React.Component {
 	};
 
 	handleInsertEmote = emote => {
-		this.chatInput.value += ` ${emote}`;
+		this.setState({
+			chatValue: this.state.chatValue + ' ' + emote
+		});
 		this.chatInput.focus();
 	};
 

--- a/src/frontend-scripts/components/section-right/generalchat.test.js
+++ b/src/frontend-scripts/components/section-right/generalchat.test.js
@@ -10,7 +10,8 @@ describe('Generalchat', () => {
 			stickyEnabled: true,
 			badWord: [null, null],
 			textLastChanged: 0,
-			textChangeTimer: -1
+			textChangeTimer: -1,
+			chatValue: ''
 		};
 
 		const component = shallow(<Generalchat />);

--- a/src/scss/style-dark.scss
+++ b/src/scss/style-dark.scss
@@ -711,6 +711,7 @@
 		position: absolute;
 		right: 52px;
 		top: 3px;
+		z-index: 10;
 		background: transparent;
 	}
 	.genchat-container .chat-user + span,
@@ -1296,7 +1297,7 @@ $eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (190
 .gameIcons {
 	position: absolute;
 	left: 17%;
-  color: lightblue;
+	color: lightblue;
 	cursor: pointer;
 	top: 10px;
 	text-decoration: underline;


### PR DESCRIPTION
Makes Generalchat and Gamechat use controlled components over direct DOM manipulation
Adds back emote button in Generalchat
Adds warnings to both when the messages are over 300 characters

Fixes #1303 