### PR TITLE
Typo in policy-powers.js

### DIFF
--- a/routes/socket/game/policy-powers.js
+++ b/routes/socket/game/policy-powers.js
@@ -1326,7 +1326,7 @@ module.exports.selectPlayerToExecute = (passport, game, data, socket) => {
 										type: 'liberal'
 									},
 									{
-										text: ' remains, top-decking to the end...'
+										text: ' remain, top-decking to the end...'
 									}
 								]
 							};


### PR DESCRIPTION
Minor typo, corrected to "Hitler and one liberal remain, top-decking to the end..." in custom games.