### PR TITLE
Home Page and Changelog Page edits REDONE

### DIFF
--- a/views/layout-no-menu.pug
+++ b/views/layout-no-menu.pug
@@ -47,11 +47,11 @@ html(lang="en")
       a(href="/discord-login" style="margin: 10px 0; background: #7289da; padding: 0; display: flex; flex-direction: row; align-items: center; justify-content: center;").button.ui.secondary.button.fluid.large.discord-signup-submit
         span Sign in with
         img(src="/images/discord-icon-2.png", style="margin-left: 5px; width: 140px; height: 50px")
-      a(href="/github-login" style="padding: 2px; border: 1px solid #666; color: #000; margin: 10px 0; background: #fff; padding: 0; display: flex; flex-direction: row; align-items: center; justify-content: center;").button.ui.secondary.button.fluid.large
+      a(href="/github-login" style="border: 1px solid #666; color: #000; margin: 10px 0; background: #fff; padding: 0; display: flex; flex-direction: row; align-items: center; justify-content: center;").button.ui.secondary.button.fluid.large
         span Sign in with
         img(src="/images/GitHub-Mark-32px.png", style="margin-left: 5px;")
-        img(src="/images/GitHub_Logo.png", style="width: 110px;")
-      p(style="text-align: center; color: black") OR
+        img(src="/images/GitHub_Logo.png", style="width: 120px;")
+      p(style="text-align: center") OR
       form.ui.form(style="text-align: center;")
         .field
           .ui.left.icon.input
@@ -65,7 +65,7 @@ html(lang="en")
         .ui.dimmer.inverted
           .ui.text.loader Signing in..
         .ui.negative.hidden.message
-        a#reset-password(style="cursor: pointer;") Forget your password?
+        a#reset-password(style="cursor: pointer; display: block; margin-top: 10px;") Forget your password?
 
     section.password-reset-modal.ui.modal.small.segment.column
       h2.header Request a password reset
@@ -83,16 +83,16 @@ html(lang="en")
     section.signup-modal.ui.modal.small.segment.column
       h2.header Sign up for an account
       p.tou By playing here, you agree to follow the #[a(href="/tou", target="_blank") Terms of Use].
-      p.tou Players with less than 2 games played can not chat in general chat, chat as an observer, or make player reports.
-      p.tou(style="color: red") WARNING: Signing Up with Discord/Github is still in beta
-      a(href="/discord-login" style="margin: 10px 0; background: #7289da; padding: 0; display: flex; flex-direction: row; align-items: center; justify-content: center;").button.ui.secondary.button.fluid.large.discord-signup-submit
+      p.tou(style="color: #888; font-size: 11px;") Players with less than 2 games played can not chat in general chat, chat as an observer, or make player reports.
+      p.tou(style="color: red") WARNING: Signing Up with Discord/Github is still in beta 
+      a(href="/discord-login" style="margin: 10px 0; background: #7289da; padding: 0; display: flex; flex-direction: row; align-items: center; justify-content: center;").button.ui.secondary.button.fluid.large
         span Sign up with
         img(src="/images/discord-icon-2.png", style="margin-left: 5px; width: 140px; height: 50px")
-      a(href="/github-login" style="padding: 2px; border: 1px solid #666; color: #000; margin: 10px 0; background: #fff; padding: 0; display: flex; flex-direction: row; align-items: center; justify-content: center;").button.ui.secondary.button.fluid.large
+      a(href="/github-login" style="border: 1px solid #666; color: #000; margin: 10px 0; background: #fff; padding: 0; display: flex; flex-direction: row; align-items: center; justify-content: center;").button.ui.secondary.button.fluid.large
         span Sign up with
         img(src="/images/GitHub-Mark-32px.png", style="margin-left: 5px;")
-        img(src="/images/GitHub_Logo.png", style="width: 110px;")
-      p(style="text-align: center; color: black") OR
+        img(src="/images/GitHub_Logo.png", style="width: 120px;")
+      p(style="text-align: center") OR
       form.ui.form
         .field
           .ui.left.icon.input
@@ -119,6 +119,7 @@ html(lang="en")
           .ui.left.icon.input
             i.envelope.outline.icon
             input#signup-email(placeholder="Email", maxlength="255", spellcheck="false")
+          .ui.info.message.hidden
         .field
           label
             input#private-player(type="checkbox", style="margin-right: 5px", name="privateWarning")

--- a/views/layout-no-menu.pug
+++ b/views/layout-no-menu.pug
@@ -84,7 +84,7 @@ html(lang="en")
       h2.header Sign up for an account
       p.tou By playing here, you agree to follow the #[a(href="/tou", target="_blank") Terms of Use].
       p.tou(style="color: #888; font-size: 11px;") Players with less than 2 games played can not chat in general chat, chat as an observer, or make player reports.
-      p.tou(style="color: red") WARNING: Signing Up with Discord/Github is still in beta 
+      p.tou(style="color: red") WARNING: Signing Up with Discord/GitHub is still in beta 
       a(href="/discord-login" style="margin: 10px 0; background: #7289da; padding: 0; display: flex; flex-direction: row; align-items: center; justify-content: center;").button.ui.secondary.button.fluid.large
         span Sign up with
         img(src="/images/discord-icon-2.png", style="margin-left: 5px; width: 140px; height: 50px")

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -232,7 +232,7 @@ html(lang="en")
       h2.header Sign up for an account
       p.tou By playing here, you agree to follow the #[a(href="/tou", target="_blank") Terms of Use].
       p.tou(style="color: #888; font-size: 11px;") Players with less than 2 games played can not chat in general chat, chat as an observer, or make player reports.
-      p.tou(style="color: red") WARNING: Signing Up with Discord/Github is still in beta 
+      p.tou(style="color: red") WARNING: Signing Up with Discord/GitHub is still in beta 
       a(href="/discord-login" style="margin: 10px 0; background: #7289da; padding: 0; display: flex; flex-direction: row; align-items: center; justify-content: center;").button.ui.secondary.button.fluid.large
         span Sign up with
         img(src="/images/discord-icon-2.png", style="margin-left: 5px; width: 140px; height: 50px")

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -45,6 +45,10 @@ html(lang="en")
         a.item(href="/game/") Game Lobby
       else
         a.item(href="/observe/") Game Lobby
+      if changelog
+        a.active.item Changelog
+      else
+        a.item(href="/changelog") Changelog
       if rules
         a.active.item Rules
       else
@@ -60,10 +64,10 @@ html(lang="en")
       else
         a.item(href="/stats") Stats
 
-      if polls
-        a.active.item Polls
+      if wiki
+        a.active.item Wiki
       else
-        a.item(href="/polls") Polls
+        a.item(href="https://github.com/cozuya/secret-hitler/wiki") Wiki
 
       if discord
         a.active.item Discord
@@ -116,10 +120,10 @@ html(lang="en")
             else
               a.item(href="/stats") Stats
 
-            if polls
-              a.active.item Polls
+            if wiki
+              a.active.item Wiki
             else
-              a.item(href="/polls") Polls
+              a.item(href="https://github.com/cozuya/secret-hitler/wiki") Wiki
 
             if discord
               a.active.item Discord

--- a/views/page-changelog.pug
+++ b/views/page-changelog.pug
@@ -4,19 +4,21 @@ block content
 		.ui.text.container
 			h1.ui.header.centered Changelog
 		.ui.text.container
-			h4 The top 10 players of season 4 are:
+			p Version 1.4.1 released 4-1-2019
+			h4 The top 10 players of season 5 are:
 			ul
-				li benjamin172: 2110
-				li minie: 2084
-				li GoldenPanda: 2017
-				li scum: 1961
-				li Moranki: 1957
-				li User: 1957
-				li Gamethrower: 1935
-				li mufasa: 1899
-				li adam: 1882
-				li Cucumber: 1879
+				li nvassOG: 1979
+				li minie: 1977
+				li Claire0536: 1937
+				li Canaris: 1915
+				li benjamin172: 1910
+				li mufasa: 1905
+				li Arrtxi: 1901
+				li RyanLockwood: 1892
+				li Anzuboi: 1862
+				li spite: 1858
 			p Version 1.4.0 released 3-27-2019
+			h4 New players have the "typing indicator" setting disabled by default - reminder, if you are experiencing laggy gameplay, turn this off yourself in the player settings. -coz
 			h4 Many Moderation Improvements -Vigasaurus
 			h4 Silent Game Features now work as intended -Vigasaurus
 			h4 Many smaller fixes and minor UI changes!
@@ -58,6 +60,18 @@ block content
 				li Lobby and cosmetic improvements @Hexicube.
 			p Version 1.0.0 released 1-1-2019
 			h3 1.0.0 and season 5 begins!
+			h4 The top 10 players of season 4 are:
+			ul
+				li benjamin172: 2110
+				li minie: 2084
+				li GoldenPanda: 2017
+				li scum: 1961
+				li Moranki: 1957
+				li User: 1957
+				li Gamethrower: 1935
+				li mufasa: 1899
+				li adam: 1882
+				li Cucumber: 1879
 			h3 Badges this season are thanks to player liberalist!
 			p It took a while, but we're here - all major features I could think of and some I couldn't are in and mostly working. A long, long way from the first stable(ish) release back in May 2017.
 			p I want to thank our moderation team first and foremost. The site would not be in the same shape without them. There was a time that feature wasn't even in and it was just a nightmare. Obviously its a combination of both the theme and the nature of a mostly anonymous internet, but they've done an amazing job keeping this place playable in public games and fun for everyone!

--- a/views/page-home.pug
+++ b/views/page-home.pug
@@ -25,7 +25,6 @@ block content
 				.eight.wide.column.news
 					h2(style="color: #000").ui.header News
 					p Issues/bugs can be reported in the #[a(href="https://discord.gg/secrethitlerio") discord development channel], or by opening a #[a(href="https://github.com/cozuya/secret-hitler/issues") github issue].
-					h3 #[a(href="/changelog") Full Changelog]
 					p Version 1.4.1 released 4-1-2019
 					h4 The top 10 players of season 5 are:
 					ul
@@ -39,61 +38,4 @@ block content
 						li RyanLockwood: 1892
 						li Anzuboi: 1862
 						li spite: 1858
-					p Version 1.4.0 released 3-27-2019
-					h4 New players have the "typing indicator" setting disabled by default - reminder, if you are experiencing laggy gameplay, turn this off yourself in the player settings. -coz
-					h4 Many Moderation Improvements -Vigasaurus
-					h4 Silent Game Features now work as intended -Vigasaurus
-					h4 Many smaller fixes and minor UI changes!
-					p Version 1.3.0 released 3-5-2019
-					h4 Fixed issue: Chats in replays work again.
-					h4 Returning feature: typing indicator (again). This has been overhauled and should work better.
-					h4 New player setting: disable typing indicator. If you feel this is adveresly affecting your browser, turn this off in your settings.
-					h4 New feature: Creategame overhaul.
-					p Thanks to Vigasaurus the create game page has been redone with many new looks and feels including some fun templates.
-					h4 Many smaller fixes and UI updates!
-					p Version 1.1.3 released 2-26-2019
-					h4 Fixed issue: problems people were having while typing in chat in mobile view.
-					h4 Returning fixed feature: claim from chat i.e. type "rrb" to make a claim without clicking on the "claim" button.
-					p Version 1.1.2 released 2-24-2019
-					h4 New feature: much better mobile/small screen width user experience -RPYoshi
-					p May not be entirely bug free -_- we'll see.
-					h4 New feature: informational popup for new accounts -coz
-					p This will attempt to explain how the site works somewhat and provide useful links to our how to play, terms of use, about, and wiki pages.
-					h4 New feature: claim directly from the chat without clicking the "claim" button - simply type what you want to claim i.e. "rrb" -Vigasaurus
-					p Hopefully won't break everything this time
-					h4 Adds 12 New Emotes -Vigasaurus
-					p Special thanks to everyone on SH.io discord server who suggested emotes
-					ul
-						li Moderators can now peek at currently locked in votes on a government -Vigasaurus
-						li Game Creation defaults now reflect results of strawpoll conducted previously -Buncha
-						li Game creation defualts should apply correctly -Vigasaurus
-						li Updated banned word list to be more exhaustive -Vigasaurus
-						li Minor bug fixes and internal changes -Vigasaurus, Spyro
-					p Version 1.0.2 released 1-20-2019
-					ul
-						li Some new moderation features (mods can force votes on afks) courtesy of contributor Vigasaurus.
-						li List of games should be like it was in 1.0.0 and lower.
-						li Contributor color has been updated.
-						li Version 1.0.1 released 1-5-2019
-					ul
-						li Signin/signup with Discord/Github should be fixed.
-						li You should no longer be logged out automatically as often.
-						li Election tracker now says its status in the gamechat after fails.
-						li Lobby and cosmetic improvements @Hexicube.
-					p Version 1.0.0 released 1-1-2019
-					h3 1.0.0 and season 5 begins!
-					h3 Badges this season are thanks to player liberalist!
-					p It took a while, but we're here - all major features I could think of and some I couldn't are in and mostly working. A long, long way from the first stable(ish) release back in May 2017.
-					p I want to thank our moderation team first and foremost. The site would not be in the same shape without them. There was a time that feature wasn't even in and it was just a nightmare. Obviously its a combination of both the theme and the nature of a mostly anonymous internet, but they've done an amazing job keeping this place playable in public games and fun for everyone!
-					p I also want to call out contributor/mod Hexicube for spending so much working on various parts of the app over the last ~year. Many moderation tools and features like custom games would not exist without him.
-					p Please note that 1.0 does not mean I am no longer supporting the application and site. Work will continue to make the site even better, but not personally at the pace I have been. My next game is in progress and I expect to get to a playable pre-alpha state some time in the next few months. It will be a (fresh IP) hidden role game with some similarities to the fascist hunting/electing game we all know and love but with some fun features and mechanics that can only exist online. Stay tuned! -Chris
-					p This update also includes:
-					ul
-						li Fixed player claims showing under player chat instead of game chat.
-						li Broadcasts will now always show regardless of filters.
-						li Fixed cardbacks sometimes failing to upload.
-						li Game remaking no longer shows "1/NaN" before the game starts on non-custom games.
-						li Fixed alts/trials showing as grey in user list.
-						li Elo slider minimum is now 1600.
-						li Cardbacks now support all image types, and all sizes.
-						li Game remaking now updates the blacklist if the creator changed theirs.
+					h2.ui.header #[a(href="/changelog") Full Changelog]


### PR DESCRIPTION
+ adds coz's last patch comment into page-changelog.pug 

+ redoes Full Changelog link and makes page-home.pug even easier to scroll.

+ removes the Polls link and replaces it with a wiki link as polls have not been added to this section for a long time and with new guides in the wiki would be beneficial to provide even more access to it from the main lobby menu similar to how github and discord were added to it awhile back.

+ adds changelog link to mobile home menu area on left side of page when the menu button is clicked. It appears now between Home/game lobby and Rules. This was not done on PC menu due to better spacing existing without. Changelog can be accessed from the bottom of the news section on mobile and PC too. Or by manually adding `/changelog` to the url.

+ UPDATED TO MATCH MOST RECENT UPDATE AND RESOLVE MERGE CONFLICTS IN #1369 

+ and improved Log In and Sign Up modals on /observe page

+ edited Github -> GitHub on Sign Up modals on home page and /observe