### PR TITLE
Removed link injection vulnerability

### DIFF
--- a/src/frontend-scripts/emotes.js
+++ b/src/frontend-scripts/emotes.js
@@ -55,7 +55,7 @@ export function processEmotes(input, isMod, allEmotes) {
 			formatedMsg.push(
 				<a
 					key={index}
-					href={isGithub ? 'https://github.com/cozuya/secret-hitler/' + data[2] : gameURL ? data[2].substring(5) : '/' + data[2]}
+					href={isGithub ? 'https://github.com/cozuya/secret-hitler/' + data[2] : gameURL ? "/game/" + data[2].substring(5) : '/' + data[2]}
 					className="shio-link"
 					title={isGithub ? "link to sh.io's github page" : 'link to something inside of sh.io'}
 				>


### PR DESCRIPTION
Typing links of the form `https://secrethitler.io///domain.com` results in the href property being set to `//domain.com`, linking to external domains. This commit fixes this by prepending `/game/` to ensure it remains local.