### PR TITLE
Always show replay chat

### DIFF
--- a/src/frontend-scripts/components/section-main/replay/Replay.jsx
+++ b/src/frontend-scripts/components/section-main/replay/Replay.jsx
@@ -197,7 +197,6 @@ class ReplayWrapper extends React.Component {
 		super();
 
 		this.state = {
-			chatsShown: false,
 			replayChats: []
 		};
 	}
@@ -219,13 +218,10 @@ class ReplayWrapper extends React.Component {
 			window.location.hash = '#/';
 			this.props.exit();
 		};
-		const toggleChats = () => {
+		const loadChats = () => {
 			if (!this.state.replayChats.length) {
 				socket.emit('getReplayGameChats', this.props.replay.game.id);
 			}
-			this.setState({
-				chatsShown: !this.state.chatsShown
-			});
 		};
 
 		const children = (() => {
@@ -245,12 +241,13 @@ class ReplayWrapper extends React.Component {
 						</h1>
 					);
 				case 'READY':
+					loadChats();
 					return (
 						<Replay
 							replay={this.props.replay}
 							isSmall={this.props.isSmall}
 							to={this.props.to}
-							replayChats={this.state.chatsShown && this.state.replayChats.length ? this.state.replayChats : []}
+							replayChats={this.state.replayChats}
 							allEmotes={this.props.allEmotes}
 						/>
 					);
@@ -259,9 +256,6 @@ class ReplayWrapper extends React.Component {
 
 		return (
 			<section id="replay" className="ui segment">
-				<button className="displaychats ui inverted blue button" onClick={toggleChats}>
-					{this.state.chatsShown ? 'Hide chats' : 'Show chats'}
-				</button>
 				<button className="exit ui inverted red button" onClick={toExit}>
 					<i className="sign out icon" />
 					Exit Replay

--- a/src/frontend-scripts/components/section-main/replay/Replay.jsx
+++ b/src/frontend-scripts/components/section-main/replay/Replay.jsx
@@ -171,24 +171,23 @@ const Replay = ({ replay, isSmall, to, replayChats, allEmotes }) => {
 						<Tracks gameInfo={gameInfo} userInfo={userInfo} />
 					</div>
 					<div className="right-side">
-						{replayChats.length ? (
-							<ReplayGamechat
-								userInfo={{}}
-								userList={{}}
-								gameInfo={{
-									chats: replayChats
-								}}
-								allEmotes={allEmotes}
-							/>
-						) : (
-							<ReplayControls turnsSize={ticks.last().turnNum + 1} turnNum={snapshot.turnNum} phase={phase} description={description} playback={playback} />
-						)}
+						<ReplayControls turnsSize={ticks.last().turnNum + 1} turnNum={snapshot.turnNum} phase={phase} description={description} playback={playback} />
 					</div>
 				</div>
 			</div>
 			<div className="row players-container">
 				<Players userList={{}} onClickedTakeSeat={null} userInfo={userInfo} gameInfo={gameInfo} isReplay socket={socket} />
 			</div>
+			{replayChats.length && (
+				<ReplayGamechat
+					userInfo={{}}
+					userList={{}}
+					gameInfo={{
+						chats: replayChats
+					}}
+					allEmotes={allEmotes}
+				/>
+			)}
 		</section>
 	);
 };

--- a/src/scss/replay.scss
+++ b/src/scss/replay.scss
@@ -8,7 +8,7 @@
 	.chats {
 		display: flex;
 		flex-direction: column-reverse;
-		height: 336px;
+		height: 250px;
 		position: relative;
 		background: #f9faff;
 		font-size: 18px;
@@ -22,7 +22,7 @@
 			position: absolute;
 			bottom: 0;
 			line-height: 1.2;
-			max-height: 336px;
+			max-height: 250px;
 			width: 98%;
 			margin: 0;
 


### PR DESCRIPTION
It's a little annoying that the replay chat replaces the replay controls UI. Users wanting to read chats have to toggle the chat box on and off to continue moving through the replay.

These changes move the replay chat to the bottom of the screen, make it permanently visible, and remove the "Show chats" button:

![image](https://user-images.githubusercontent.com/9055029/71350745-9a471480-2537-11ea-8da6-1090de870fff.png)
