### PR TITLE
ELO Housekeeping

### DIFF
--- a/routes/socket/util.js
+++ b/routes/socket/util.js
@@ -134,7 +134,7 @@ module.exports.secureGame = secureGame;
 const avg = (accounts, accessor) => accounts.reduce((prev, curr) => prev + accessor(curr), 0) / accounts.length;
 
 // Calculates the bias in elo points
-const probToEloPoints = (p) => 400 * Math.log10((1/p) - 1);
+const probToEloPoints = (p) => -400 * Math.log10((1/p) - 1);
 
 // The probability of this team winning in this game size, given perfectly equal teams, in terms of elo points
 const winnerBiasPoints = (game) => {
@@ -154,7 +154,7 @@ const winnerBiasPoints = (game) => {
 			case 8: return probToEloPoints(.5 + (0.04 * liberalBias));
 			case 9: return probToEloPoints(.5 + (0.08 * fascistBias));
 			case 10: return probToEloPoints(.5 + (0.04 * fascistBias));
-			default: return .5;
+			default: return 0;
 		}
 	}
 };


### PR DESCRIPTION
1. Added helpful comments
2. Added new way to calculate bias from the stats page
3. Added specific game biases for 'rebal' games
4. Updated the bias using the current stats
5. Generally just cleaned some stuff up

This should be ready for merge, but I am a little rusty and can't be bothered to fully test this tonight, so I thought I'd leave this up for peer review.

If someone wants to test this: Nothing noticeable should be different. If you play a game and ELO works like normal, its working correctly.

This might be the first of a series of small ELO updates. We will see... It sets the stage for things like auto-updating biases and other cool stuff.