### PR TITLE
Feature: Add support for docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Default to ignoring all files and folders starting with a dot
+.*
+
+# Make an exception for .babelrc
+!.babelrc
+
+# Ignore the tests directory
+__test__/
+coverage/
+
+# Ignore node_modules
+node_modules/
+
+# Ignore documentation
+.md
+.txt
+
+# Ignore logs
+.log
+
+# Ignore initial MongoDB data
+data/
+

--- a/.env
+++ b/.env
@@ -1,6 +1,5 @@
 SECRETSESSIONKEY='hunter2'
 
 # MONGODB_URI='mongodb://localhost:27017'
-# MONGODB_DB='secret-hitler-app'
 
 # REDIS_HOST='localhost'

--- a/.env
+++ b/.env
@@ -1,1 +1,6 @@
 SECRETSESSIONKEY='hunter2'
+
+# MONGODB_URI='mongodb://localhost:27017'
+# MONGODB_DB='secret-hitler-app'
+
+# REDIS_HOST='localhost'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:12
+
+WORKDIR /application
+
+COPY ./ ./
+
+RUN yarn --ignore-engines --frozen-lockfile
+RUN yarn build
+
+ENTRYPOINT node bin/dev.js

--- a/app.js
+++ b/app.js
@@ -19,14 +19,14 @@ let store;
 if (process.env.NODE_ENV !== 'production') {
 	const MongoDBStore = require('connect-mongodb-session')(session);
 	store = new MongoDBStore({
-		uri: 'mongodb://localhost:27017/secret-hitler-app',
+		uri: `${process.env.MONGODB_URI || 'mongodb://localhost:27017'}/secret-hitler-app`,
 		collection: 'sessions'
 	});
 } else {
 	const redis = require('redis').createClient();
 	const RedisStore = require('connect-redis')(session);
 	store = new RedisStore({
-		host: '127.0.0.1',
+		host: process.env.REDIS_HOST || '127.0.0.1',
 		port: 6379,
 		client: redis,
 		ttl: 2 * 604800 // 2 weeks
@@ -121,7 +121,7 @@ if (process.env.DISCORDCLIENTID) {
 
 passport.serializeUser(Account.serializeUser());
 passport.deserializeUser(Account.deserializeUser());
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`, { useNewUrlParser: true, useUnifiedTopology: true });
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`, { useNewUrlParser: true, useUnifiedTopology: true });
 mongoose.set('useCreateIndex', true);
 mongoose.set('useFindAndModify', false);
 mongoose.Promise = global.Promise;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  mongodb:
+    image: mongo:latest
+    volumes:
+    - ./data:/data/db
+    ports: 
+      - 27017:27017
+
+  redis:
+    image: redis:latest
+    ports:
+      - 6379:6379
+
+  secret-hitler:
+    build: .
+    restart: always
+    depends_on:
+      - mongodb
+      - redis
+    environment: 
+      MONGODB_URI: mongodb://mongodb:27017
+      REDIS_HOST: redis
+      SECRETSESSIONKEY: hunter2
+    ports:
+      - 8080:8080

--- a/routes/socket/util.js
+++ b/routes/socket/util.js
@@ -185,7 +185,7 @@ module.exports.destroySession = username => {
 
 		let mongoClient;
 
-		Mongoclient.connect('mongodb://localhost:27017', { useNewUrlParser: true }, (err, client) => {
+		Mongoclient.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017', { useNewUrlParser: true }, (err, client) => {
 			mongoClient = client;
 		});
 

--- a/scripts/account/reset-password.js
+++ b/scripts/account/reset-password.js
@@ -1,9 +1,10 @@
+require('dotenv').config();
 const mongoose = require('mongoose');
 const Account = require('../../models/account');
 
 if (process.argv.length === 3) {
 	mongoose.Promise = global.Promise;
-	mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+	mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 	const username = process.argv[2];
 	const user = Account.findOne({ username });
 	user.setPassword('ChangeMe123', () => {

--- a/scripts/addEndofSeasonRewards.js
+++ b/scripts/addEndofSeasonRewards.js
@@ -1,8 +1,9 @@
+require('dotenv').config();
 const mongoose = require('mongoose');
 const Account = require('../models/account');
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 const bronze = [];
 const silver = [];

--- a/scripts/addUsernamesToProfiles.js
+++ b/scripts/addUsernamesToProfiles.js
@@ -1,8 +1,9 @@
+require('dotenv').config();
 const mongoose = require('mongoose');
 const Profile = require('../models/profile');
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 Profile.find({})
 	.cursor()

--- a/scripts/assignBaseElo.js
+++ b/scripts/assignBaseElo.js
@@ -1,8 +1,9 @@
+require('dotenv').config();
 const Account = require('../models/account');
 const mongoose = require('mongoose');
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 let count = 0;
 

--- a/scripts/assignHashuidsToPlayers.js
+++ b/scripts/assignHashuidsToPlayers.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const mongoose = require('mongoose');
 const Game = require('../models/game');
 const moment = require('moment');
@@ -63,7 +64,7 @@ const tenPlayerGameData = {
 };
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 Game.find({})
 	.cursor()

--- a/scripts/assignLocalMod.js
+++ b/scripts/assignLocalMod.js
@@ -1,9 +1,10 @@
+require('dotenv').config();
 const mongoose = require('mongoose');
 const Account = require('../models/account');
 const successfulAdmins = [];
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 Account.find({ username: { $in: ['Uther', 'admin'] } })
 	.cursor()

--- a/scripts/assignLocalToAllAccountsPriorToOauth.js
+++ b/scripts/assignLocalToAllAccountsPriorToOauth.js
@@ -1,8 +1,9 @@
+require('dotenv').config();
 const Account = require('../models/account'); // temp
 const mongoose = require('mongoose');
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 let count = 0;
 

--- a/scripts/banDisposables.js
+++ b/scripts/banDisposables.js
@@ -1,9 +1,10 @@
+require('dotenv').config();
 const Account = require('../models/account');
 const mongoose = require('mongoose');
 const fs = require('fs');
 const emails = require('../utils/disposableEmails.js');
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`, { useNewUrlParser: true });
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`, { useNewUrlParser: true });
 
 let count = 0;
 let processed = 0;

--- a/scripts/clearBlacklists.js
+++ b/scripts/clearBlacklists.js
@@ -1,8 +1,9 @@
+require('dotenv').config();
 const Account = require('../../models/account'); // temp
 const mongoose = require('mongoose');
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 let count = 0;
 

--- a/scripts/deleteBlacklists.js
+++ b/scripts/deleteBlacklists.js
@@ -1,8 +1,9 @@
+require('dotenv').config();
 const Account = require('../models/account'); // temp
 const mongoose = require('mongoose');
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 let count = 0;
 

--- a/scripts/dumpGameSummariesAnon.js
+++ b/scripts/dumpGameSummariesAnon.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
@@ -12,7 +13,7 @@ if (![2, 3, 5, 6].includes(process.argv.length)) {
 }
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`, { useNewUrlParser: true });
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`, { useNewUrlParser: true });
 
 const now = new Date();
 console.log('Starting at', now);

--- a/scripts/dumpGames.js
+++ b/scripts/dumpGames.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const child_process = require('child_process');
 const fs = require('fs');
 const os = require('os');
@@ -49,7 +50,7 @@ dumpDateTo = `${endDate.getFullYear()}-${endDate.getMonth() + 1}-${endDate.getDa
 
 // Connect to mongo
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 // Dump summaries for the day
 const summaries = [];

--- a/scripts/dumpGamesAnon.js
+++ b/scripts/dumpGamesAnon.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
@@ -8,7 +9,7 @@ const Account = require('../models/account');
 const Game = require('../models/game');
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 const OUTPUT_DIR = '/var/www/secret-hitler/public/game-dumps';
 const GAMES_DIR = `${OUTPUT_DIR}/games`;

--- a/scripts/pruneAccounts.js
+++ b/scripts/pruneAccounts.js
@@ -1,8 +1,9 @@
+require('dotenv').config();
 const Account = require('../models/account');
 const mongoose = require('mongoose');
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`, { useNewUrlParser: true });
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`, { useNewUrlParser: true });
 
 let count = 0;
 

--- a/scripts/rating/allGames.js
+++ b/scripts/rating/allGames.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const mongoose = require('mongoose');
 const Game = require('../../models/game'); // temp
 
@@ -6,7 +7,7 @@ let count = 0;
 module.exports = async rate => {
 	try {
 		mongoose.Promise = global.Promise;
-		await mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+		await mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 		const cursor = await Game.find({}, { chats: 0 })
 			.limit(5000)
 			.cursor();

--- a/scripts/rating/clearRatings.js
+++ b/scripts/rating/clearRatings.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const Account = require('../../models/account'); // temp
 const mongoose = require('mongoose');
 
@@ -6,7 +7,7 @@ let count = 0;
 async function clearRatings() {
 	try {
 		mongoose.Promise = global.Promise;
-		await mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+		await mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 		await Account.find()
 			.cursor()
 			.eachAsync(account => {

--- a/scripts/rating/nthRatings.js
+++ b/scripts/rating/nthRatings.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const Summary = require('../../models/game-summary');
 const Account = require('../../models/account');
 const buildEnhancedGameSummary = require('../../models/game-summary/buildEnhancedGameSummary');
@@ -127,7 +128,7 @@ async function rate(summary) {
 async function allSummaries(rate) {
 	try {
 		mongoose.Promise = global.Promise;
-		await mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+		await mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 		const cursor = await Summary.find().cursor();
 		for (let summary = await cursor.next(); summary != null; summary = await cursor.next()) {
 			// Ignore casual games

--- a/scripts/rating/printRatings.js
+++ b/scripts/rating/printRatings.js
@@ -1,10 +1,11 @@
+require('dotenv').config();
 const Account = require('../../models/account'); // temp
 const mongoose = require('mongoose');
 
 async function clearRatings() {
 	try {
 		mongoose.Promise = global.Promise;
-		await mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+		await mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 		await Account.find()
 			.sort('-eloSeason')
 			.cursor()

--- a/scripts/retrieveGameData.js
+++ b/scripts/retrieveGameData.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const mongoose = require('mongoose');
 const Game = require('../models/game');
 const moment = require('moment');
@@ -63,7 +64,7 @@ const tenPlayerGameData = {
 };
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 Game.find({})
 	.cursor()

--- a/scripts/retrieveLeaderboardData.js
+++ b/scripts/retrieveLeaderboardData.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const mongoose = require('mongoose');
 const Account = require('../models/account');
 const fs = require('fs');
@@ -7,7 +8,7 @@ const data = {
 };
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 Account.find({ lastCompletedGame: { $gte: new Date(Date.now() - 86400000) } })
 	.cursor()

--- a/scripts/retroactivelyAddAprilGames.js
+++ b/scripts/retroactivelyAddAprilGames.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const mongoose = require('mongoose');
 const Game = require('../models/game');
 const Account = require('../models/account');
@@ -5,7 +6,7 @@ const Account = require('../models/account');
 let count = 0;
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 Game.find({
 	date: {

--- a/scripts/writeGames.js
+++ b/scripts/writeGames.js
@@ -1,11 +1,12 @@
 /* eslint-disable */
+require('dotenv').config();
 const fs = require('fs');
 const mongoose = require('mongoose');
 const Game = require('../models/game-summary/index');
 const Account = require('../models/account');
 
 mongoose.Promise = global.Promise;
-mongoose.connect(`mongodb://localhost:27017/secret-hitler-app`);
+mongoose.connect(`${process.env.MONGODB_URI || 'localhost:27017'}/secret-hitler-app`);
 
 String.prototype.hashCode = function() {
 	var hash = 0,


### PR DESCRIPTION
Similar story as #1544 here - wanted to play with friends as IRL wasn't an option, in the end we moved to another online SH, which "missed" some polish.

Anyway, this PR could just as well have been three separate ones:
1. Add support for setting MongoDB and Redis hostname through environment variables, as `localhost` in Docker world would point to the local container. The original defaults are still in the code, as to keep maximum backwards compatibility.
1. Containerized the application by adding a `Dockerfile` and `.dockerignore`. Nothing special here, it just installs dependencies and builds the application based on a `node:12` image.
1. A docker-compose file, which orchestrates a SH, MongoDB and Redis container simply by running `docker-compose up`. Exposing SH at port 8080.

I have tried to keep the PR contained to getting docker-compose to work, as such there's still some possible improvements to be made in all areas of this PR. (Everything works to my knowledge 🤞 , they are more it-would-be-nice-if's. E.g. integrate with CI, using a smaller base image, use env vars for Redis port.)

As to why would one want to have env vars, Docker and docker-compose support. 
* Reproducibility, no more ["it works on my machine"](https://i.imgflip.com/24ac74.jpg)
* Easy deployment of small instances with docker-compose, both for small "private" production instances and development.**
 * Continuous Integration, e.g. spin up a SH instance and run end-to-end tests against it on every commit. (Recently did something similar [here](https://github.com/Addono/LISA/blob/master/.github/workflows/continuous-integration.yaml), using Cypress.io for e2e testing.)

*Yes, this could be avoided by using a network of type "host", however this is not supported on non-Linux distributions. 
**Currently the docker-compose is a bit in-between production and dev: It uses prod config wherever possible, as such there's no file watching support. But at the same it is very bare minimum, e.g. no proxy to handle static files, making it unsuitable for using it at scale. IMO, the latter wouldn't be worthwhile, as there are better container orchestration platforms, although they are not as easy to get started with as docker-compose. 