### PR TITLE
Fix online player count and refactor code

### DIFF
--- a/public/scripts/site.js
+++ b/public/scripts/site.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
 			contentType: 'application/json; charset=UTF-8',
 			statusCode: {
 				200: function(d) {
-					$('.chrome.icon').after('<span>' + d.count + ' </span>');
+					$("#player-count").text(d.count);
 				}
 			}
 		});

--- a/views/page-home.pug
+++ b/views/page-home.pug
@@ -2,17 +2,16 @@ extends layout
 block content
 	if username
 		a(href="/game/") Game Lobby
-			#header-container.ui.segment
-				div.online-count
-					i.chrome.icon
-					| players online now
-
-	else
+	else 
 		a(href="/observe/") Game Lobby
-			#header-container.ui.segment
-				div.online-count
-					i.chrome.icon
-					| players online now
+	#header-container.ui.segment
+		.private-callout
+			a(href="https://private.secrethitler.io") Here to play private games?  Click here to use our new new private server.
+		div.online-count
+			i.chrome.icon
+			span#player-count 
+			|  players online now
+
 
 	.ui.segment
 		.ui.grid.mainpage


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13847095/78153383-494e9280-743b-11ea-8b39-bae4b901cdf7.png)
The part for online player count was badly implemented, it relied on chrome icon element. So when you switched chrome icon, the player count broke. This way it can work normally even after the icon is replaced. Also, while I was working on that fix, I saw that I could refactor and reduce some code in `views/page-home.pug`.