### PR TITLE
Remove zero-width spaces from moderation.test.js

### DIFF
--- a/src/frontend-scripts/components/section-main/moderation.test.js
+++ b/src/frontend-scripts/components/section-main/moderation.test.js
@@ -33,7 +33,7 @@ describe('Moderation', () => {
 			filterModalVisibility: false,
 			filterValue: '',
 			showGameIcons: false,
-			​lagMeterStatus​:​ ​'​'
+			lagMeterStatus: ''
 		};
 
 		const component = shallow(<Moderation socket={{ on: jest.fn(), emit: jest.fn() }} />);

--- a/src/frontend-scripts/components/section-main/moderation.test.js
+++ b/src/frontend-scripts/components/section-main/moderation.test.js
@@ -29,10 +29,11 @@ describe('Moderation', () => {
 				type: 'username',
 				direction: 'descending'
 			},
-			hideActions: false,
 			filterModalVisibility: false,
 			filterValue: '',
-			showGameIcons: false,
+			showActions: true,
+			showGameIcons: true,
+			tableCollapsed: false,
 			lagMeterStatus: ''
 		};
 


### PR DESCRIPTION
https://github.com/cozuya/secret-hitler/commit/2a4a7386bca904801eb4274fb30c89e1985c8092 introduced zero-width spaces into `moderation.test.js`. On my Mac 10.15.4, this causes Jest to fail with a syntax error:

```
 FAIL  src/frontend-scripts/components/section-main/moderation.test.js
  ● Test suite failed to run

    SyntaxError: /Users/jhemphill/oss/secret-hitler/src/frontend-scripts/components/section-main/moderation.test.js: Unexpected character '' (36:3)

      34 | 			filterValue: '',
      35 | 			showGameIcons: false,
    > 36 | 			lagMeterStatus: ''
         | 			^
      37 | 		};
      38 | 
      39 | 		const component = shallow(<Moderation socket={{ on: jest.fn(), emit: jest.fn() }} />);
```

Now `moderation.test.js` fails with a different error on my machine:

```
 FAIL  src/frontend-scripts/components/section-main/moderation.test.js
  ● Moderation › should initialize correctly

    expect(received).toEqual(expected)

    Difference:

    - Expected
    + Received

    @@ -6,11 +6,10 @@
        "gameList": Array [],
        "gameSort": Object {
          "direction": "descending",
          "type": "username",
        },
    -   "hideActions": false,
        "lagMeterStatus": "",
        "log": Array [],
        "logCount": 1,
        "logSort": Object {
          "direction": "descending",
    @@ -20,11 +19,13 @@
        "nonSeasonalSetStats": false,
        "playerInputText": "",
        "playerListState": 0,
        "resetServerCount": 0,
        "selectedUser": "",
    -   "showGameIcons": false,
    +   "showActions": true,
    +   "showGameIcons": true,
    +   "tableCollapsed": false,
        "userList": Array [],
        "userSort": Object {
          "direction": "descending",
          "type": "username",
        },

      39 | 		const component = shallow(<Moderation socket={{ on: jest.fn(), emit: jest.fn() }} />);
      40 | 
    > 41 | 		expect(component.state()).toEqual(initialState);
         | 		                         ^
      42 | 	});
      43 | });
      44 | 

      at Object.toEqual (src/frontend-scripts/components/section-main/moderation.test.js:41:29)
```

But at least the file parses now...