### PR TITLE
node-sass -> 4.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
 		"jest-cli": "^24.1.0",
 		"moment": "^2.18.1",
 		"node-notifier": "^5.1.2",
-		"node-sass": "^4.13.0",
+		"node-sass": "^4.14.0",
 		"npm-run-all": "^4.1.5",
 		"prettier": "^1.19.1",
 		"pretty-quick": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7847,10 +7847,10 @@ node-releases@^1.1.3:
   dependencies:
     semver "^5.3.0"
 
-node-sass@^4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.0.tgz#b647288babdd6a1cb726de4545516b31f90da066"
-  integrity sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==
+node-sass@^4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.0.tgz#a8e9d7720f8e15b4a1072719dcf04006f5648eeb"
+  integrity sha512-AxqU+DFpk0lEz95sI6jO0hU0Rwyw7BXVEv6o9OItoXLyeygPeaSpiV4rwQb10JiTghHaa0gZeD21sz+OsQluaw==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"


### PR DESCRIPTION
node-sass 4.13.0 doesn't support the latest version of NodeJS, but 4.14.0 does.