### PR TITLE
Keep chat anonymized when user stands up 

### DIFF
--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -648,10 +648,10 @@ class Gamechat extends React.Component {
 											: `${chat.userName} {${gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName) + 1}}`
 										: chat.staffRole === 'moderator' && chat.userName === 'Incognito' && canSeeIncognito
 										? chat.hiddenUsername
-										: isBlind
+										: isBlind && !isMod
 										? '?'
 										: chat.userName
-									: isBlind
+									: isBlind && (!isMod || (isMod && isSeated))
 									? '?'
 									: chat.staffRole === 'moderator' && chat.userName === 'Incognito' && canSeeIncognito
 									? chat.hiddenUsername

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -648,8 +648,10 @@ class Gamechat extends React.Component {
 											: `${chat.userName} {${gameInfo.publicPlayersState.findIndex(publicPlayer => publicPlayer.userName === chat.userName) + 1}}`
 										: chat.staffRole === 'moderator' && chat.userName === 'Incognito' && canSeeIncognito
 										? chat.hiddenUsername
+										: isBlind
+										? '?'
 										: chat.userName
-									: isBlind && isSeated
+									: isBlind
 									? '?'
 									: chat.staffRole === 'moderator' && chat.userName === 'Incognito' && canSeeIncognito
 									? chat.hiddenUsername

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -425,7 +425,6 @@ class Gamechat extends React.Component {
 	};
 
 	processChats() {
-		const processStart = new Date();
 		const { gameInfo, userInfo, userList } = this.props;
 		const { gameSettings } = userInfo;
 		const isBlind = gameInfo.general && gameInfo.general.blindMode && !gameInfo.gameState.isCompleted;
@@ -664,11 +663,6 @@ class Gamechat extends React.Component {
 				);
 				return acc;
 			}, []);
-			// DEBUG
-			const processEnd = new Date();
-			if (processEnd - processStart > 25) {
-				console.warn('It took', processEnd - processStart, 'ms to process', gameInfo.chats.length, 'chats.');
-			}
 			return processedChats;
 		}
 	}


### PR DESCRIPTION
Fixes #1633. 

Now:
* When a non-mod user who has made a message in a blind game stands up, their name appears as "?".
* If the game starts and they have sat down, their chats from before the game started become under their anonymized name.
* If the game starts and they have not sat down, their name remains as "?".
* If a mod observing the game sends a message, their name is displayed. However, if they sit down, their name becomes "?" like the other users.