### PR TITLE
show games a player is seated in at top of games list

### DIFF
--- a/src/frontend-scripts/components/section-main/GamesList.jsx
+++ b/src/frontend-scripts/components/section-main/GamesList.jsx
@@ -183,9 +183,16 @@ export class GamesList extends React.Component {
 					);
 				})
 				.sort((a, b) => {
+					const userInGame =
+						userInfo && userInfo.userName && a.userNames && a.userNames.includes(userInfo.userName)
+							? -1
+							: userInfo && userInfo.userName && b.userNames && b.userNames.includes(userInfo.userName)
+							? 1
+							: 0;
+
 					const statusSortOrder = ['notStarted', 'isStarted', 'fascist', 'liberal'];
 					const diff = Math.min(2, statusSortOrder.indexOf(a.gameStatus)) - Math.min(2, statusSortOrder.indexOf(b.gameStatus));
-					return diff || sortTypeThenName(a, b);
+					return userInGame || diff || sortTypeThenName(a, b);
 				})
 				.map((game, index) => (
 					<DisplayLobbies key={game.uid} game={game} socket={this.props.socket} userList={this.props.userList} userInfo={this.props.userInfo} />


### PR DESCRIPTION
Fixes one part of #1656 (that if you are seated in a game, it appears at the top of the games list).

Example: you are seated in a game in progress, so it appears above a game that has not started.
![image](https://user-images.githubusercontent.com/17211794/87088257-553fb280-c1e9-11ea-8048-5ed460bfbb54.png)
