### PR TITLE
Prevent replay tracks from getting distorted when turn description overflows

### DIFF
--- a/src/scss/replay.scss
+++ b/src/scss/replay.scss
@@ -249,6 +249,10 @@
 		overflow: hidden !important;
 		position: relative;
 
+		@media screen and (min-width: 650px) {
+			height: 440px;
+		}
+
 		.card-group {
 			height: 50%;
 


### PR DESCRIPTION
Fixes #1709, though there are still more replay formatting issues that could be fixed.