### PR TITLE
Confirm Execution Modal and Setting

### DIFF
--- a/models/account.js
+++ b/models/account.js
@@ -31,6 +31,7 @@ const Account = new Schema({
 		disableCrowns: Boolean,
 		disableSeasonal: Boolean,
 		disableAggregations: Boolean,
+		disableKillConfirmation: Boolean,
 		soundStatus: String,
 		unbanTime: Date,
 		unTimeoutTime: Date,

--- a/src/frontend-scripts/components/section-main/Players.jsx
+++ b/src/frontend-scripts/components/section-main/Players.jsx
@@ -235,7 +235,7 @@ class Players extends React.Component {
 				onClick={() => {
 					if (!gameSettings.disableKillConfirmation && gameState.phase === 'execution') {
 						Swal.fire({
-							title: `Are you sure you want to execute ${i + 1}. ${player.userName}?`,
+							title: `Are you sure you want to execute {${i + 1}} ${player.userName}?`,
 							showCancelButton: true,
 							icon: 'warning'
 						}).then(result => {

--- a/src/frontend-scripts/components/section-main/Players.jsx
+++ b/src/frontend-scripts/components/section-main/Players.jsx
@@ -233,7 +233,19 @@ class Players extends React.Component {
 			<div
 				key={i}
 				onClick={() => {
-					this.handlePlayerClick(i);
+					if (!gameSettings.disableKillConfirmation && gameState.phase === 'execution') {
+						Swal.fire({
+							title: `Are you sure you want to execute ${i + 1}. ${player.userName}?`,
+							showCancelButton: true,
+							icon: 'warning'
+						}).then(result => {
+							if (result.value) {
+								this.handlePlayerClick(i);
+							}
+						});
+					} else {
+						this.handlePlayerClick(i);
+					}
 				}}
 				style={
 					player.customCardback &&

--- a/src/frontend-scripts/components/section-main/Settings.jsx
+++ b/src/frontend-scripts/components/section-main/Settings.jsx
@@ -33,6 +33,7 @@ class Settings extends React.Component {
 		disableCrowns: '',
 		disableSeasonal: '',
 		disableElo: '',
+		disableKillConfirmation: '',
 		disableAggregations: '',
 		soundStatus: '',
 		isPrivate: '',
@@ -73,6 +74,7 @@ class Settings extends React.Component {
 			disableConfetti: gameSettings.disableConfetti || '',
 			disableSeasonal: gameSettings.disableSeasonal || '',
 			disableElo: gameSettings.disableElo || '',
+			disableKillConfirmation: gameSettings.disableKillConfirmation || '',
 			disableAggregations: gameSettings.disableAggregations || '',
 			isPrivate: gameSettings.isPrivate || '',
 			fullheight: gameSettings.fullheight || false,
@@ -772,6 +774,16 @@ class Settings extends React.Component {
 									name="disableaggregations"
 									checked={this.state.disableAggregations}
 									onChange={() => this.toggleGameSettings('disableAggregations')}
+								/>
+								<label />
+							</div>
+							<h4 className="ui header">Disable kill confirmation</h4>
+							<div className="ui fitted toggle checkbox">
+								<input
+									type="checkbox"
+									name="disablekillconfirmation"
+									checked={this.state.disableKillConfirmation}
+									onChange={() => this.toggleGameSettings('disableKillConfirmation')}
 								/>
 								<label />
 							</div>


### PR DESCRIPTION
Fixes #1591 
Defaults to showing the modal unless the setting to disable it is made true. Picture is outdated. Instead of `3. Thrall` it is now `{3} Thrall`.
![confirm](https://user-images.githubusercontent.com/38539079/94098007-467e9a00-fded-11ea-9b93-76b1501b9dec.png)
