### PR TITLE
General Chat "Lock Chat" Button Fix

### DIFF
--- a/src/frontend-scripts/components/section-right/Generalchat.jsx
+++ b/src/frontend-scripts/components/section-right/Generalchat.jsx
@@ -184,7 +184,11 @@ export default class Generalchat extends React.Component {
 	};
 
 	handleChatLockClick = () => {
-		this.setState({ lock: !this.state.lock });
+		if (this.state.lock) {
+			this.setState({ lock: false });
+		} else {
+			this.setState({ lock: true });
+		}
 	};
 
 	handleChatScrolled = () => {


### PR DESCRIPTION
Fixes the "lock chat" button for the general/lobby chat. Was already functioning for gamechat, but now works for lobby chat.
![generallobbychatlockchatfix](https://user-images.githubusercontent.com/50686515/94179629-c26af780-fe6a-11ea-868a-1e266e9a0927.gif)