### PR TITLE
Add a callback fallback (fix the crash when malformed player report data is passed to socket)

### DIFF
--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -3987,10 +3987,12 @@ module.exports.handlePlayerReport = (passport, data, callback) => {
 			});
 		});
 
-		if (reportError) {
-			callback({ success: false, error: 'Error submitting report.' });
-		} else {
-			callback({ success: true });
+		if (typeof callback === 'function') {
+			if (reportError) {
+				callback({ success: false, error: 'Error submitting report.' });
+			} else {
+				callback({ success: true });
+			}
 		}
 	});
 };


### PR DESCRIPTION
Fixes #1744.

P.S. I made this PR from the GitHub CLI.

