### PR TITLE
keep sticky closed after navigating to a different page

### DIFF
--- a/src/frontend-scripts/components/section-main/GamesList.jsx
+++ b/src/frontend-scripts/components/section-main/GamesList.jsx
@@ -9,8 +9,7 @@ import { processEmotes } from '../../emotes';
 
 export class GamesList extends React.Component {
 	state = {
-		filtersVisible: false,
-		stickyEnabled: true
+		filtersVisible: false
 	};
 
 	toggleFilter = value => {
@@ -24,21 +23,20 @@ export class GamesList extends React.Component {
 		const { generalChats } = this.props;
 		const nextGeneralChats = nextProps.generalChats;
 
-		if (!this.state.stickyEnabled && generalChats.sticky !== nextGeneralChats.sticky) {
-			this.setState({
-				stickyEnabled: true
-			});
+		if (!this.props.stickyEnabled && generalChats.sticky !== nextGeneralChats.sticky) {
+			this.props.setStickyEnabled(true);
 		}
 	}
 
 	renderSticky = () => {
-		if (this.state.stickyEnabled && this.props.generalChats && this.props.generalChats.sticky) {
-			const dismissSticky = () => {
-				this.setState({ stickyEnabled: false });
-			};
-
+		if (this.props.stickyEnabled && this.props.generalChats && this.props.generalChats.sticky) {
 			return (
-				<Message onDismiss={dismissSticky} color="blue">
+				<Message
+					onDismiss={() => {
+						this.props.setStickyEnabled(false);
+					}}
+					color="blue"
+				>
 					{processEmotes(this.props.generalChats.sticky, true, this.props.allEmotes)}
 				</Message>
 			);

--- a/src/frontend-scripts/components/section-main/Main.jsx
+++ b/src/frontend-scripts/components/section-main/Main.jsx
@@ -34,7 +34,8 @@ export class Main extends React.Component {
 				casualgame: false
 			},
 			showNewPlayerModal: Boolean(window.hasNotDismissedSignupModal),
-			newPlayerModalPageIndex: 0
+			newPlayerModalPageIndex: 0,
+			stickyEnabled: true
 		};
 	}
 
@@ -53,6 +54,10 @@ export class Main extends React.Component {
 	static getDerivedStateFromProps(props) {
 		return props.userInfo.gameSettings ? { gameFilter: props.userInfo.gameSettings.gameFilters } : null;
 	}
+
+	setStickyEnabled = enabled => {
+		this.setState({ stickyEnabled: enabled });
+	};
 
 	handleDismissSignupModal = () => {
 		this.setState({
@@ -273,6 +278,8 @@ export class Main extends React.Component {
 							gameFilter={this.state.gameFilter}
 							generalChats={this.props.generalChats}
 							allEmotes={this.props.allEmotes}
+							stickyEnabled={this.state.stickyEnabled}
+							setStickyEnabled={this.setStickyEnabled}
 						/>
 					);
 			}

--- a/src/frontend-scripts/components/section-main/gameslist.test.js
+++ b/src/frontend-scripts/components/section-main/gameslist.test.js
@@ -5,8 +5,7 @@ import GamesList from './GamesList';
 describe('GamesList', () => {
 	it('should initialize correctly', () => {
 		const initialState = {
-			filtersVisible: false,
-			stickyEnabled: true
+			filtersVisible: false
 		};
 
 		const component = shallow(<GamesList />);

--- a/src/frontend-scripts/components/section-main/main.test.js
+++ b/src/frontend-scripts/components/section-main/main.test.js
@@ -18,7 +18,8 @@ describe('Main', () => {
 				casualgame: false
 			},
 			showNewPlayerModal: Boolean(window.hasNotDismissedSignupModal),
-			newPlayerModalPageIndex: 0
+			newPlayerModalPageIndex: 0,
+			stickyEnabled: true
 		};
 
 		const component = shallow(<Main userInfo={{}} />);


### PR DESCRIPTION
Does what the title says. I.e. if the user closes a sticky, then goes into a game, the sticky will still be closed when they return to the main page.