### PR TITLE
Discord Mod Log Test Fix

### DIFF
--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -3844,7 +3844,7 @@ module.exports.handleModerationAction = (socket, passport, data, skipCheck, modU
 
 			const modAction = JSON.stringify({
 				content: `Date: *${new Date()}*\nStaff member: **${modaction.modUserName}**\nAction: **${niceAction[modaction.actionTaken] ||
-					modaction.actionTaken}**\nUser: **${modaction.userActedOn}**\nComment: **${modaction.modNotes}**.`
+					modaction.actionTaken}**\nUser: **${modaction.userActedOn} **\nComment: **${modaction.modNotes}**.`
 			});
 
 			const modOptions = {


### PR DESCRIPTION
Fixes a small text formatting issue in mod log when performing a mod action that doesn't have a user.

Before:
![04_#96](https://user-images.githubusercontent.com/50686515/95026256-155c6000-065e-11eb-8afe-fb837c74802d.png)
After:
![04_#97](https://user-images.githubusercontent.com/50686515/95026255-155c6000-065e-11eb-9574-6ffeb22a0c32.png)

tbh, this should make the next update v2.0.0 considering how much work it required ;)