### PR TITLE
Extends the Elo color range

### DIFF
--- a/src/frontend-scripts/components/section-right/Playerlist.jsx
+++ b/src/frontend-scripts/components/section-right/Playerlist.jsx
@@ -637,7 +637,7 @@ class Playerlist extends React.Component {
 						</p>
 						<p>
 							The color of a rainbow player depends on their ELO, a type of matchmaking rating. The spectrum of colors goes from deep green as lowest ELO to
-							deep purple as highest ELO, passing through yellow and orange on its way.
+							deep indigo as highest ELO, passing through yellow, orange, red, and purple on its way.
 						</p>
 						<p>
 							Additionally, <span className="admin">Administrators</span> have a <span className="admin">red color</span> with a{' '}

--- a/src/frontend-scripts/constants.js
+++ b/src/frontend-scripts/constants.js
@@ -82,8 +82,8 @@ export const PLAYERCOLORS = (user, isSeasonal, defaultClass, eloDisabled) => {
 		let grade;
 		if (elo < 1500) {
 			grade = 0;
-		} else if (elo > 2000) {
-			grade = 500 / 5;
+		} else if (elo > 2100) {
+			grade = 600 / 5;
 		} else {
 			grade = (elo - 1500) / 5;
 		}

--- a/src/frontend-scripts/node-constants.js
+++ b/src/frontend-scripts/node-constants.js
@@ -82,8 +82,8 @@ module.exports.PLAYERCOLORS = (user, isSeasonal, defaultClass, eloDisabled) => {
 		let grade;
 		if (elo < 1500) {
 			grade = 0;
-		} else if (elo > 2000) {
-			grade = 500 / 5;
+		} else if (elo > 2100) {
+			grade = 600 / 5;
 		} else {
 			grade = (elo - 1500) / 5;
 		}

--- a/src/scss/players.scss
+++ b/src/scss/players.scss
@@ -1,4 +1,4 @@
-$eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (1900 0.9 1 0.6) (2000 0.8 1 0.4);
+$eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (1900 0.9 1 0.6) (2000 0.8 1 0.4) (2100 0.7 1 0.5);
 
 @function lerp($low, $high, $elo) {
 	$scale: nth($high, 1) - nth($low, 1);
@@ -64,7 +64,7 @@ $eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (190
 			background: $tourny;
 		}
 	}
-	@for $i from 0 through 100 {
+	@for $i from 0 through 120 {
 		.player-container.elo#{$i} {
 			box-shadow: 0 0 5px 2px calcEloCol($i * 5+1500) !important;
 		}

--- a/src/scss/profile.scss
+++ b/src/scss/profile.scss
@@ -1,4 +1,4 @@
-$eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (1900 0.9 1 0.6) (2000 0.8 1 0.4);
+$eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (1900 0.9 1 0.6) (2000 0.8 1 0.4) (2100 0.7 1 0.5);
 
 @function lerp($low, $high, $elo) {
 	$scale: nth($high, 1) - nth($low, 1);
@@ -58,7 +58,7 @@ $eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (190
 		background-repeat: no-repeat;
 	}
 
-	@for $i from 0 through 100 {
+	@for $i from 0 through 120 {
 		.profile-picture.elo#{$i} {
 			box-shadow: 0 0 5px 2px calcEloCol($i * 5+1500) !important;
 		}

--- a/src/scss/style-dark.scss
+++ b/src/scss/style-dark.scss
@@ -963,7 +963,7 @@ div {
 	margin-left: -237px;
 }
 
-$eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (1900 0.9 1 0.6) (2000 0.8 1 0.4);
+$eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (1900 0.9 1 0.6) (2000 0.8 1 0.4) (2100 0.7 1 0.5);
 
 @function lerp($low, $high, $elo) {
 	$scale: nth($high, 1) - nth($low, 1);
@@ -1004,7 +1004,7 @@ $eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (190
 	@return lerp($low, $high, $elo);
 }
 
-@for $i from 0 through 100 {
+@for $i from 0 through 120 {
 	.elo#{$i} {
 		color: calcEloCol($i * 5+1500) !important;
 	}


### PR DESCRIPTION
## Changes

Essentially, I have logically extended the Elo color interpolation formula so as to create 20 new Elo colors, the "highest" one going to those with 2100 Elo and up.

## Screenshots

Here's the new 2100 color! 

<img width="44" alt="Screen Shot 2021-03-15 at 10 00 49 PM" src="https://user-images.githubusercontent.com/49939932/111258291-f1705380-85d9-11eb-8ef9-6442c94f277e.png">

---


## Tested Locally
- [ ] This PR has been tested locally, and ensured to not cause any breaking changes
- [X] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

## Changelog
- [X] Changelog Section below has been updated with Changelog entry
- [ ] This PR does not make a user-facing change

### Changelog Entry (delete this section if this PR does not need a changelog entry)

Check one, delete the other:
- [X] New Feature
- [ ] Bug Fix

Check one, delete the other:
- [ ] Major Change
- [X] Minor Change

**Changelog Headline**: Elo color range now extends to 2100!

**Changelog Details**: To reward our highest-elo players, players will now be able to attain differentiating Elo colors for up to 2100 Elo.
