### PR TITLE
Fixes safari board blur issues

### DIFF
--- a/src/scss/tracks.scss
+++ b/src/scss/tracks.scss
@@ -208,9 +208,12 @@
 	}
 }
 
-.tracks.blurred,
+.tracks.blurred {
+	filter: saturate(60%);
+	opacity: 0.3;
+}
 .enactedpolicies-container.blurred {
-	//filter: blur(5px) saturate(60%);
+	filter: saturate(60%);
 	opacity: 0.3;
 }
 .help-message {

--- a/src/scss/tracks.scss
+++ b/src/scss/tracks.scss
@@ -208,10 +208,7 @@
 	}
 }
 
-.tracks.blurred {
-	filter: saturate(60%);
-	opacity: 0.3;
-}
+.tracks.blurred,
 .enactedpolicies-container.blurred {
 	filter: saturate(60%);
 	opacity: 0.3;


### PR DESCRIPTION
## Changes

Fixes #1597 

Please describe the changes made in the pull request here.

## Screenshots

Here's what it looks like with the fix on Safari (the same as it looks on Chrome right now):
<img width="650" alt="Screen Shot 2021-03-16 at 3 13 49 PM" src="https://user-images.githubusercontent.com/49939932/111389191-c6374400-866d-11eb-8eba-8a13bb1b6675.png">
Here's what it looked like without the fix on Safari:
<img width="652" alt="Screen Shot 2021-03-16 at 3 13 43 PM" src="https://user-images.githubusercontent.com/49939932/111389203-c9cacb00-866d-11eb-9c57-b06b2e125f56.png">


## Tested Locally
- [ ] This PR has been tested locally, and ensured to not cause any breaking changes
- [X] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

## Changelog
- [X] Changelog Section below has been updated with Changelog entry
- [ ] This PR does not make a user-facing change

### Changelog Entry (delete this section if this PR does not need a changelog entry)

Check one, delete the other:
- [ ] New Feature
- [X] Bug Fix

Check one, delete the other:
- [ ] Major Change
- [X] Minor Change

**Changelog Headline**: Disappearing track glitch in Safari browser fixed!

**Changelog Details**: Now, when the Ja and Nein (or policy card) popups happen in the Safari browser, the background is only partially blurred out, to be consistent with the appearance on Chrome and other browsers.
