### PR TITLE
Adding game type to player reports

### DIFF
--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -3993,8 +3993,8 @@ module.exports.handlePlayerReport = (passport, data, callback) => {
 
 	const body = JSON.stringify({
 		content: `${
-			data.uid ? `Game UID: <https://secrethitler.io/game/#/table/${data.uid}>` : 'Report from homepage'
-		}\nReported player: ${blindModeAnonymizedPlayer}\nReason: ${playerReport.reason}\nGame Type: ${playerReport.gameType}\nComment: ${httpEscapedComment}`
+			data.uid ? `Game UID: <https://secrethitler.io/game/#/table/${data.uid}> (${playerReport.gameType})` : 'Report from homepage'
+		}\nReported player: ${blindModeAnonymizedPlayer}\nReason: ${playerReport.reason}\nComment: ${httpEscapedComment}`
 	});
 
 	const options = {

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -721,7 +721,7 @@ module.exports.handleAddNewGame = (socket, passport, data) => {
 			timedMode: typeof data.timedMode === 'number' && data.timedMode >= 2 && data.timedMode <= 6000 ? data.timedMode : false,
 			flappyMode: data.flappyMode,
 			flappyOnlyMode: data.flappyMode && data.flappyOnlyMode,
-			casualGame: typeof data.timedMode === 'number' && data.timedMode < 30 ? true : data.gameType === 'casual',
+			casualGame: data.casualGame || (typeof data.timedMode === 'number' && data.timedMode < 30) ? true : data.gameType === 'casual',
 			practiceGame: !(typeof data.timedMode === 'number' && data.timedMode < 30) && data.gameType === 'practice',
 			rebalance6p: data.rebalance6p,
 			rebalance7p: data.rebalance7p,

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -3994,7 +3994,7 @@ module.exports.handlePlayerReport = (passport, data, callback) => {
 	const body = JSON.stringify({
 		content: `${
 			data.uid ? `Game UID: <https://secrethitler.io/game/#/table/${data.uid}>` : 'Report from homepage'
-		}\nReported player: ${blindModeAnonymizedPlayer}\nReason: ${playerReport.reason}\nComment: ${httpEscapedComment}`
+		}\nReported player: ${blindModeAnonymizedPlayer}\nReason: ${playerReport.reason}\nGame Type: ${playerReport.gameType}\nComment: ${httpEscapedComment}`
 	});
 
 	const options = {


### PR DESCRIPTION
## Changes

Just adds the game type to player report messages on discord

## Tested Locally
- [ ] This PR has been tested locally, and ensured to not cause any breaking changes
- [X] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

## Changelog
- [X] Changelog Section below has been updated with Changelog entry
- [ ] This PR does not make a user-facing change

### Changelog Entry (delete this section if this PR does not need a changelog entry)

Check one, delete the other:
- [x] New Feature
- [ ] Bug Fix

Check one, delete the other:
- [ ] Major Change
- [X] Minor Change

**Changelog Headline**: Game type is now displayed in #player-reports on Discord

**Changelog Details**: Pretty self-explanatory
