### PR TITLE
change binding from j/k to left/right arrow keys

### DIFF
--- a/src/frontend-scripts/components/section-main/replay/ReplayControls.jsx
+++ b/src/frontend-scripts/components/section-main/replay/ReplayControls.jsx
@@ -135,16 +135,18 @@ const Description = ({ description }) => {
 const Playback = ({ hasNext, hasPrev, next, prev, forward, backward, beginning, end }) => {
 	const onKeyDown = event => {
 		// ignore typing in textboxes
+		const leftKeyCode = 37;
+		const rightKeyCode = 39;
 		if (['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) return;
 		const char = String.fromCharCode(event.keyCode);
-		if (char === 'H' && hasPrev) {
-			backward();
-		} else if (event.keyCode === 37 && hasPrev) {
-			prev();
-		} else if (event.keyCode === 39 && hasNext) {
-			next();
-		} else if (char === 'L' && hasNext) {
-			forward();
+		if ((char === 'H' && hasPrev) || (event.shiftKey && event.keyCode == leftKeyCode)) {
+			return backward();
+		} else if (char === 'J' || (event.keyCode === leftKeyCode && hasPrev)) {
+			return prev();
+		} else if ((char === 'L' && hasNext) || (event.shiftKey && event.keyCode == rightKeyCode)) {
+			return forward();
+		} else if (char === 'K' || (event.keyCode === rightKeyCode && hasNext)) {
+			return next();
 		}
 	};
 

--- a/src/frontend-scripts/components/section-main/replay/ReplayControls.jsx
+++ b/src/frontend-scripts/components/section-main/replay/ReplayControls.jsx
@@ -139,9 +139,9 @@ const Playback = ({ hasNext, hasPrev, next, prev, forward, backward, beginning, 
 		const char = String.fromCharCode(event.keyCode);
 		if (char === 'H' && hasPrev) {
 			backward();
-		} else if (char === 'J' && hasPrev) {
+		} else if (event.keyCode === 37 && hasPrev) {
 			prev();
-		} else if (char === 'K' && hasNext) {
+		} else if (event.keyCode === 39 && hasNext) {
 			next();
 		} else if (char === 'L' && hasNext) {
 			forward();

--- a/src/frontend-scripts/components/section-main/replay/ReplayControls.jsx
+++ b/src/frontend-scripts/components/section-main/replay/ReplayControls.jsx
@@ -139,13 +139,13 @@ const Playback = ({ hasNext, hasPrev, next, prev, forward, backward, beginning, 
 		const rightKeyCode = 39;
 		if (['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) return;
 		const char = String.fromCharCode(event.keyCode);
-		if ((char === 'H' && hasPrev) || (event.shiftKey && event.keyCode == leftKeyCode)) {
+		if ((char === 'H' || (event.shiftKey && event.keyCode == leftKeyCode)) && hasPrev) {
 			return backward();
-		} else if (char === 'J' || (event.keyCode === leftKeyCode && hasPrev)) {
+		} else if ((char === 'J' || event.keyCode === leftKeyCode) && hasPrev) {
 			return prev();
-		} else if ((char === 'L' && hasNext) || (event.shiftKey && event.keyCode == rightKeyCode)) {
+		} else if ((char === 'L' || (event.shiftKey && event.keyCode == rightKeyCode)) && hasNext) {
 			return forward();
-		} else if (char === 'K' || (event.keyCode === rightKeyCode && hasNext)) {
+		} else if ((char === 'K' || event.keyCode === rightKeyCode) && hasNext) {
 			return next();
 		}
 	};


### PR DESCRIPTION
## Changes

- maintain hjkl replay keys, add left/right and shift + left/right controls

## Screenshots

not very useful but tested locally
![image](https://user-images.githubusercontent.com/59436696/112067254-ab7a3900-8b5f-11eb-8e71-a08978ab2fc0.png)

---

### Below you'll find a checklist. For each item on the list, check one option (if completed) and delete the other as appropriate. (Delete this line too)

## Tested Locally
- [X] This PR has been tested locally, and ensured to not cause any breaking changes
- [X] This PR makes a trivial change

## Tests
- [] Automated tests have been added
- [X] This PR does not require tests

## Changelog
- [X] Changelog Section below has been updated with Changelog entry
- [ ] This PR does not make a user-facing change

### Changelog Entry (delete this section if this PR does not need a changelog entry)

Check one, delete the other:
- [X] New Feature - not really a new feature but an enhancement for more intuitive replay controls


Check one, delete the other:
- [X] Minor Change

**Changelog Headline**: maintain hjkl replay keys, add left/right and shift + left/right controls

**Changelog Details**: 
replay controls will now be: 
Use j/k or left/right arrow keys on replay to go backward/forward one tick
Use h/l or shift + left/right arrow keys on replay to go backward/forward one gov

