### PR TITLE
Fixing card vanishing glitch

### DIFF
--- a/src/scss/tracks.scss
+++ b/src/scss/tracks.scss
@@ -208,9 +208,12 @@
 	}
 }
 
-.tracks.blurred,
+.tracks.blurred {
+	filter: saturate(60%);
+	opacity: 0.3;
+}
 .enactedpolicies-container.blurred {
-	//filter: blur(5px) saturate(60%);
+	filter: saturate(60%);
 	opacity: 0.3;
 }
 .help-message {

--- a/src/scss/tracks.scss
+++ b/src/scss/tracks.scss
@@ -208,10 +208,7 @@
 	}
 }
 
-.tracks.blurred {
-	filter: saturate(60%);
-	opacity: 0.3;
-}
+.tracks.blurred,
 .enactedpolicies-container.blurred {
 	filter: saturate(60%);
 	opacity: 0.3;

--- a/src/scss/tracks.scss
+++ b/src/scss/tracks.scss
@@ -208,9 +208,11 @@
 	}
 }
 
-.tracks.blurred,
-.enactedpolicies-container.blurred {
+.tracks.blurred.blurred {
 	filter: saturate(60%);
+	opacity: 0.3;
+}
+.enactedpolicies-container.blurred {
 	opacity: 0.3;
 }
 .help-message {


### PR DESCRIPTION
## Changes

After the safari blur glitch was fixed, cards now disappear on some browsers during voting. This should fix that.

## Tested Locally
- [ ] This PR has been tested locally, and ensured to not cause any breaking changes
- [X] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

## Changelog
- [X] Changelog Section below has been updated with Changelog entry
- [ ] This PR does not make a user-facing change

### Changelog Entry (delete this section if this PR does not need a changelog entry)

Check one, delete the other:
- [ ] New Feature
- [X] Bug Fix

Check one, delete the other:
- [ ] Major Change
- [X] Minor Change

**Changelog Headline**: Card vanishing glitched fixed!

**Changelog Details**: Policy cards no longer disappear during voting on some browsers
