### PR TITLE
Card vanish fix

### DIFF
--- a/src/scss/tracks.scss
+++ b/src/scss/tracks.scss
@@ -208,9 +208,11 @@
 	}
 }
 
-.tracks.blurred,
-.enactedpolicies-container.blurred {
+.tracks.blurred {
 	filter: saturate(60%);
+	opacity: 0.3;
+}
+.enactedpolicies-container.blurred {
 	opacity: 0.3;
 }
 .help-message {


### PR DESCRIPTION
## Changes

After the safari blur was fixed, on some browsers, like Chrome, the policy cards started disappearing during voting. This should fix that


## Tested Locally
- [ ] This PR has been tested locally, and ensured to not cause any breaking changes
- [X] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

## Changelog
- [X] Changelog Section below has been updated with Changelog entry
- [ ] This PR does not make a user-facing change

### Changelog Entry (delete this section if this PR does not need a changelog entry)

Check one, delete the other:
- [ ] New Feature
- [X] Bug Fix

Check one, delete the other:
- [ ] Major Change
- [X] Minor Change

**Changelog Headline**: Disappearing card glitch fixed

**Changelog Details**: Policy cards no longer disappear during voting in some browsers
