### PR TITLE
Fixing #1447 (Chrome card flip glitch)

### DIFF
--- a/src/scss/players.scss
+++ b/src/scss/players.scss
@@ -205,8 +205,6 @@ $eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (190
 			transition-property: transform, top;
 			transform-style: preserve-3d;
 			position: relative;
-			-webkit-backface-visibility: hidden; // thanks osx safari
-			backface-visibility: hidden;
 			.card {
 				background-size: cover;
 				background-repeat: no-repeat;
@@ -318,6 +316,9 @@ $eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (190
 			.card-back {
 				-webkit-backface-visibility: hidden; // thanks osx safari
 				backface-visibility: hidden;
+				transform: rotateY(180deg);
+			}
+			.card-front {
 				transform: rotateY(180deg);
 			}
 			.blacklist {


### PR DESCRIPTION
## Changes

Right now, when the vote cards flip over upon completion of a vote, the flip animation is broken on Chrome and causes the cards to disappear mid-flip. This small change fixes this, making it consistent across browsers

### Below you'll find a checklist. For each item on the list, check one option (if completed) and delete the other as appropriate. (Delete this line too)

## Tested Locally
- [ ] This PR has been tested locally, and ensured to not cause any breaking changes
- [X] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

## Changelog
- [X] Changelog Section below has been updated with Changelog entry
- [ ] This PR does not make a user-facing change

### Changelog Entry (delete this section if this PR does not need a changelog entry)

Check one, delete the other:
- [ ] New Feature
- [X] Bug Fix

Check one, delete the other:
- [ ] Major Change
- [X] Minor Change

**Changelog Headline**: Card flip animation fixed!

**Changelog Details**: Google Chrome now displays the proper card flip animation when voting completes
