### PR TITLE
fixing reversed ballot card error

### DIFF
--- a/src/scss/players.scss
+++ b/src/scss/players.scss
@@ -326,13 +326,19 @@ $eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (190
 				background-image: url('../../public/images/cards/membership-fascist.png');
 			}
 			.card-back {
-				-webkit-backface-visibility: hidden; // thanks osx safari
 				backface-visibility: hidden;
+				-webkit-backface-visibility: hidden;
+				-moz-backface-visibility: hidden;
+				-ms-backface-visibility: hidden;
+				-o-backface-visibility: hidden;
 				transform: rotateY(180deg);
 			}
 			.card-front {
-				-webkit-backface-visibility: hidden; // thanks osx safari
 				backface-visibility: hidden;
+				-webkit-backface-visibility: hidden;
+				-moz-backface-visibility: hidden;
+				-ms-backface-visibility: hidden;
+				-o-backface-visibility: hidden;
 			}
 			.blacklist {
 				top: -100px !important;

--- a/src/scss/players.scss
+++ b/src/scss/players.scss
@@ -331,7 +331,8 @@ $eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (190
 				transform: rotateY(180deg);
 			}
 			.card-front {
-				transform: rotateY(180deg);
+				-webkit-backface-visibility: hidden; // thanks osx safari
+				backface-visibility: hidden;
 			}
 			.blacklist {
 				top: -100px !important;


### PR DESCRIPTION
## Changes

Fixes an unfortunate error I created in which the ballot card appears horizontally flipped. I tested this with Chrome and Safari  on mac and it works there at least!

## Tested Locally
- [ ] This PR has been tested locally, and ensured to not cause any breaking changes
- [X] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

## Changelog
- [X] Changelog Section below has been updated with Changelog entry
- [ ] This PR does not make a user-facing change

### Changelog Entry (delete this section if this PR does not need a changelog entry)

Check one, delete the other:
- [ ] New Feature
- [X] Bug Fix

Check one, delete the other:
- [ ] Major Change
- [X] Minor Change

**Changelog Headline**: Ballot card flip error fixed!

**Changelog Details**: ?blamenixon
