### PR TITLE
Makes "Editors" reflects current editors

### DIFF
--- a/src/frontend-scripts/components/section-right/Playerlist.jsx
+++ b/src/frontend-scripts/components/section-right/Playerlist.jsx
@@ -643,15 +643,13 @@ class Playerlist extends React.Component {
 							Additionally, <span className="admin">Administrators</span> have a <span className="admin">red color</span> with a{' '}
 							<span className="admin-name">(A)</span> and are always at the top of the list.
 							<br />
-							<span className="cbell">Ed</span>
-							<span className="max">it</span>
-							<span className="moira">or</span>
-							<span className="thejuststopo">s</span>, placed at the top just below <span className="admin">Administrators</span>, have a range of special
+							<span className="anji">Ed</span>
+							<span className="bruno">it</span>
+							<span className="moira">ors</span>, placed at the top just below <span className="admin">Administrators</span>, have a range of special
 							colors to stand out, as well as a <span className="admin">(E)</span>.<br />
-							<span className="moderatorcolor">Moderators</span>, placed at the top below <span className="cbell">Ed</span>
-							<span className="max">it</span>
-							<span className="moira">or</span>
-							<span className="thejuststopo">s</span>, have a <span className="moderatorcolor">blue color</span> with a{' '}
+							<span className="moderatorcolor">Moderators</span>, placed at the top below <span className="anji">Ed</span>
+							<span className="bruno">it</span>
+							<span className="moira">ors</span>, have a <span className="moderatorcolor">blue color</span> with a{' '}
 							<span className="moderatorcolor">(M)</span>.<br />
 							AEM <span className="veteran">Veterans</span> are retired senior moderators, and are given a <span className="veteran">teal</span> color.
 							<br />

--- a/src/frontend-scripts/components/section-right/Playerlist.jsx
+++ b/src/frontend-scripts/components/section-right/Playerlist.jsx
@@ -645,12 +645,12 @@ class Playerlist extends React.Component {
 							<br />
 							<span className="anji">Ed</span>
 							<span className="bruno">it</span>
-							<span className="moira">ors</span>, placed at the top just below <span className="admin">Administrators</span>, have a range of special
-							colors to stand out, as well as a <span className="admin">(E)</span>.<br />
+							<span className="moira">ors</span>, placed at the top just below <span className="admin">Administrators</span>, have a range of special colors to
+							stand out, as well as a <span className="admin">(E)</span>.<br />
 							<span className="moderatorcolor">Moderators</span>, placed at the top below <span className="anji">Ed</span>
 							<span className="bruno">it</span>
-							<span className="moira">ors</span>, have a <span className="moderatorcolor">blue color</span> with a{' '}
-							<span className="moderatorcolor">(M)</span>.<br />
+							<span className="moira">ors</span>, have a <span className="moderatorcolor">blue color</span> with a <span className="moderatorcolor">(M)</span>.
+							<br />
 							AEM <span className="veteran">Veterans</span> are retired senior moderators, and are given a <span className="veteran">teal</span> color.
 							<br />
 							Lastly, <span className="contributor">Contributors</span> get a <span className="contributor">special color</span> as well! Contribute code to


### PR DESCRIPTION
Editor colors have been changed from those of cbell, Max, moira, and TheJustStopO to Anji, Bruno, and moira.

## Changes

Editor colors were updated in the Info box to reflect the current Editor team.

---

### Below you'll find a checklist. For each item on the list, check one option (if completed) and delete the other as appropriate. (Delete this line too)

## Tested Locally
- [ ] This PR has been tested locally, and ensured to not cause any breaking changes
- [X] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

## Changelog
- [ ] Changelog Section below has been updated with Changelog entry
- [X] This PR does not make a user-facing change
