### PR TITLE
Make in-progress games delete 2 minutes after all players leave

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -234,8 +234,10 @@ module.exports = () => {
 			return;
 		}
 
-		renderPage(req, res, '403', '403');
-		return;
+		if (process.env.NODE_ENV === 'production') {
+			renderPage(req, res, '403', '403');
+			return;
+		}
 
 		const backgroundColor = DEFAULTTHEMECOLORS.baseBackgroundColor;
 		const textColor = DEFAULTTHEMECOLORS.baseTextColor;

--- a/routes/socket/routes.js
+++ b/routes/socket/routes.js
@@ -74,19 +74,21 @@ const gamesGarbageCollector = () => {
 	Object.keys(games).forEach(gameName => {
 		let toDelete = false;
 		const currentGame = games[gameName];
+		if (!currentGame) return;
+
 		const createdTimer =
-			currentGame &&
 			currentGame.general &&
 			currentGame.general.timeCreated &&
 			currentGame.gameState &&
 			!currentGame.gameState.isStarted &&
 			new Date(currentGame.general.timeCreated.getTime() + 600000);
 		const completedTimer =
-			currentGame &&
 			currentGame.gameState &&
 			currentGame.gameState.isCompleted &&
 			currentGame.gameState.timeCompleted &&
 			new Date(currentGame.gameState.timeCompleted + 1000 * 60 * 2);
+		const allPlayersLeftTimer =
+			currentGame.general && currentGame.general.allPlayersLeft && new Date(currentGame.general.allPlayersLeft.getTime() + 1000 * 60 * 2);
 
 		// To come maybe later
 		// const modDeleteTimer = games[gameName].general.modDeleteDelay && new Date(games[gameName].general.modDeleteDelay.getTime() + 900000);
@@ -107,14 +109,11 @@ const gamesGarbageCollector = () => {
 		// 	createdTimer
 		// );
 
-		if (games[gameName] && createdTimer && createdTimer < currentTime) {
-			// console.log('Created Timer Expired. Deleting... ');
-			toDelete = true;
-		}
-		if (games[gameName] && !games[gameName].general.modDeleteDelay && completedTimer && completedTimer < currentTime) {
-			// console.log('Completed Game Timer Expired. Deleting... ');
-			toDelete = true;
-		}
+		toDelete =
+			(createdTimer && createdTimer < currentTime) ||
+			(!games[gameName].general.modDeleteDelay && completedTimer && completedTimer < currentTime) ||
+			(allPlayersLeftTimer && allPlayersLeftTimer < currentTime);
+
 		// if (games[gameName] && modDeleteTimer && modDeleteTimer < currentTime) {
 		// console.log('Mod Delete Delay Timer Expired. Deleting... ');
 		// toDelete = true;

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -306,7 +306,7 @@ const handleSocketDisconnect = socket => {
 					}
 					sendInProgressGameUpdate(game);
 					if (game.publicPlayersState.filter(publicPlayer => publicPlayer.leftGame).length === game.general.playerCount) {
-						saveAndDeleteGame(game.general.uid);
+						game.general.allPlayersLeft = new Date();
 					}
 				}
 			});
@@ -397,7 +397,7 @@ const handleUserLeaveGame = (socket, game, data, passport) => {
 			game.publicPlayersState[playerIndex].leftGame = true;
 		}
 		if (game.publicPlayersState.filter(publicPlayer => publicPlayer.leftGame).length === game.general.playerCount) {
-			saveAndDeleteGame(game.general.uid);
+			game.general.allPlayersLeft = new Date();
 		}
 		if (!game.gameState.isTracksFlipped) {
 			game.publicPlayersState.splice(

--- a/routes/socket/user-requests.js
+++ b/routes/socket/user-requests.js
@@ -354,6 +354,7 @@ module.exports.sendGameInfo = (socket, uid) => {
 			if (player) {
 				player.leftGame = false;
 				player.connected = true;
+				if (game.general) game.general.allPlayersLeft = null;
 				socket.emit('updateSeatForUser', true);
 				updateUserStatus(passport, game);
 			} else {


### PR DESCRIPTION
## Changes

When all players leave an in-progress game, deletion is queued by the garbage collector and will occur at least two minutes after everyone left.

## Screenshots

These are effectively required for non-trivial changes, but appreciated for all.

---

## Tested Locally
- [x] This PR has been tested locally, and ensured to not cause any breaking changes
- [ ] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

## Changelog
- [ ] Changelog Section below has been updated with Changelog entry
- [x] This PR does not make a user-facing change
