### PR TITLE
Vote signalling fix

### DIFF
--- a/routes/socket/game/start-game.js
+++ b/routes/socket/game/start-game.js
@@ -576,4 +576,7 @@ module.exports = game => {
 	});
 	game.gameState.audioCue = '';
 	game.private.policies = [];
+	game.private.voteSpamData = game.private.seatedPlayers.map(player => ({
+		unvoteTimer: -1
+	}));
 };


### PR DESCRIPTION
Basically, every time you unvote it waits 2s to emit it to all the clients (which resets if you spam votes). For the average user, the only effect is that there is a 2s delay between unvoting and seeing it. For vote signallers, it's now impossible to spam the spinner on the cardback because the unvote keeps getting held back by the spam. Tested and should work as intended for both normal voting and vote spamming. This was WAY easier to do like this, my original solution without timers was absolute hell.