### PR TITLE
Changing inv game default to 2 reg fascists

### DIFF
--- a/src/frontend-scripts/components/section-main/Creategame.jsx
+++ b/src/frontend-scripts/components/section-main/Creategame.jsx
@@ -834,7 +834,7 @@ export default class Creategame extends React.Component {
 						powers: ['investigate', 'reverseinv', 'investigate', 'reverseinv', 'investigate'], // last "power" is always a fas victory
 						hitlerZone: 3, // 1-5
 						vetoZone: 5, // 1-5, must be larger than fas track state
-						fascistCount: 1, // 1-3, does not include hit
+						fascistCount: 2, // 1-3, does not include hit
 						hitKnowsFas: false,
 						fasCanShootHit: false,
 						deckState: { lib: 6, fas: 15 }, // includes tracks cards; 6 deck + 1 track = 5 in deck


### PR DESCRIPTION
## Changes

Simply changing the Inv Game default button to having 2 reg fascists instead of 1, because people generally like playing 4v3 instead of 5v2

## Tested Locally
- [ ] This PR has been tested locally, and ensured to not cause any breaking changes
- [X] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

## Changelog
- [X] Changelog Section below has been updated with Changelog entry
- [ ] This PR does not make a user-facing change

### Changelog Entry (delete this section if this PR does not need a changelog entry)

Check one, delete the other:
- [X] New Feature
- [ ] Bug Fix

Check one, delete the other:
- [ ] Major Change
- [X] Minor Change

**Changelog Headline**: Inv Game Button Adjustment!

**Changelog Details**: No more accidental 2 fascist games. All of our lives are now 1% easier due to this default button change.
