### PR TITLE
Blanket Ban List Mod Tool

### DIFF
--- a/models/blanketBanIP.js
+++ b/models/blanketBanIP.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+const BlanketBanIP = new Schema({
+	bb: String,
+	account: String,
+	ip: String
+});
+
+module.exports = mongoose.model('BlanketBanIP', BlanketBanIP);

--- a/routes/index.js
+++ b/routes/index.js
@@ -380,16 +380,15 @@ module.exports = () => {
 		const username = req.session.passport.user;
 		Account.findOne({ username }).then(account => {
 			if (account.staffRole === 'moderator' || account.staffRole === 'editor' || account.staffRole === 'admin') {
-				BlanketBanIP.find()
-					.then(accs => {
-						var csvContent = '';
-						accs.forEach(acc => {
-							const newline = [obfIP(acc.ip),acc.bb,acc.account].join(",") + "\r\n";
-							csvContent += newline;
-						});
-						res.set('Content-Type', 'text/csv');
-						res.send(csvContent);
-					})
+				BlanketBanIP.find().then(accs => {
+					var csvContent = '';
+					accs.forEach(acc => {
+						const newline = [obfIP(acc.ip), acc.bb, acc.account].join(',') + '\r\n';
+						csvContent += newline;
+					});
+					res.set('Content-Type', 'text/csv');
+					res.send(csvContent);
+				});
 			} else {
 				res.status(401).send('You cannot access this resource. Ensure you are logged in.');
 			}

--- a/routes/index.js
+++ b/routes/index.js
@@ -384,7 +384,7 @@ module.exports = () => {
 					.then(accs => {
 						var csvContent = '';
 						accs.forEach(acc => {
-							const newline = [obfIP(acc.ip),acc.bb,acc.account].join(",") + "\r\n"
+							const newline = [obfIP(acc.ip),acc.bb,acc.account].join(",") + "\r\n";
 							csvContent += newline;
 						});
 						res.set('Content-Type', 'text/csv');

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,7 @@ const Account = require('../models/account'); // eslint-disable-line no-unused-v
 const { getProfile } = require('../models/profile/utils');
 const GameSummary = require('../models/game-summary');
 const ModThread = require('../models/modThread');
+const BlanketBanIP = require('../models/blanketBanIP');
 const Profile = require('../models/profile');
 const { socketRoutes } = require('./socket/routes');
 const _ = require('lodash');
@@ -369,6 +370,26 @@ module.exports = () => {
 						}
 					})
 					.catch(err => debug(err));
+			} else {
+				res.status(401).send('You cannot access this resource. Ensure you are logged in.');
+			}
+		});
+	});
+
+	app.get('/bbCSV', (req, res) => {
+		const username = req.session.passport.user;
+		Account.findOne({ username }).then(account => {
+			if (account.staffRole === 'moderator' || account.staffRole === 'editor' || account.staffRole === 'admin') {
+				BlanketBanIP.find()
+					.then(accs => {
+						var csvContent = '';
+						accs.forEach(acc => {
+							const newline = [obfIP(acc.ip),acc.bb,acc.account].join(",") + "\r\n"
+							csvContent += newline;
+						});
+						res.set('Content-Type', 'text/csv');
+						res.send(csvContent);
+					})
 			} else {
 				res.status(401).send('You cannot access this resource. Ensure you are logged in.');
 			}

--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -2925,7 +2925,7 @@ module.exports.handleModerationAction = (socket, passport, data, skipCheck, modU
 					Account.findOne({ username: data.userName })
 						.then(acc => {
 							if (acc) {
-								BlanketBanIP.deleteMany({account: data.userName}, (err, res) => {
+								BlanketBanIP.deleteMany({ account: data.userName }, (err, res) => {
 									if (err) socket.emit('sendAlert', `IP remove failed:\n${err}`);
 								});
 							} else {

--- a/src/frontend-scripts/components/section-main/Moderation.jsx
+++ b/src/frontend-scripts/components/section-main/Moderation.jsx
@@ -804,6 +804,32 @@ export default class Moderation extends React.Component {
 					</div>
 				</div>
 				<br />
+				<div className="ui horizontal divider">Blanket Ban Database</div>
+				<button
+					style={{ background: 'lightcoral' }}
+					className={(selectedUser || playerInputText) && actionTextValue ? 'ui button ipban-button' : 'ui button disabled ipban-button'}
+					onClick={() => {
+						takeModAction('addbb');
+					}}
+				>
+					Add Blanket Ban IP
+				</button>
+				<button
+					style={{ background: 'greenyellow' }}
+					className={(selectedUser || playerInputText) && actionTextValue ? 'ui button ipban-button' : 'ui button disabled ipban-button'}
+					onClick={() => {
+						takeModAction('removebb');
+					}}
+				>
+					Remove Blanket Ban IP
+				</button>
+				<button
+					style={{ width: '100%', background: 'lightgrey' }}
+					className={'ui button'}
+					onClick={() => { window.open("/bbCSV", "_blank"); }}
+				>
+					Download Blanket Ban Spreadsheet
+				</button>
 				<div className="ui horizontal divider" style={{ color: 'red' }}>
 					🔰 Editors/Admins Only 📛
 				</div>
@@ -1166,6 +1192,9 @@ export default class Moderation extends React.Component {
 			getIP: 'Get IP',
 			ban: 'Ban',
 			setSticky: 'Set Sticky',
+			addbb: 'Add Blanket Ban IP',
+			removebb: 'Remove Blanket Ban IP',
+			showbb: 'Download BB Spreadsheet',
 			ipbanlarge: '1 Week IP Ban',
 			ipban: '18 Hour IP Ban',
 			enableAccountCreation: 'Enable Account Creation',

--- a/src/frontend-scripts/components/section-main/Moderation.jsx
+++ b/src/frontend-scripts/components/section-main/Moderation.jsx
@@ -826,7 +826,9 @@ export default class Moderation extends React.Component {
 				<button
 					style={{ width: '100%', background: 'lightgrey' }}
 					className={'ui button'}
-					onClick={() => { window.open("/bbCSV", "_blank"); }}
+					onClick={() => {
+						window.open('/bbCSV', '_blank');
+					}}
 				>
 					Download Blanket Ban Spreadsheet
 				</button>


### PR DESCRIPTION
## Changes

Adds a new mod tool which allows accounts belonging to Blanket Banned players to be tracked. It allows a CSV spreadsheet to be downloaded which gives their current obfuscated IPs.

## Screenshots

I'm not sure if I should add screenshots of the mod tools but I can provide them if you need them!

---

## Tested Locally
- [X] This PR has been tested locally, and ensured to not cause any breaking changes
- [ ] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

## Changelog
- [ ] Changelog Section below has been updated with Changelog entry
- [x] This PR does not make a user-facing change
