### PR TITLE
Mirror game notes in local storage for persistence

### DIFF
--- a/src/frontend-scripts/components/Gamenotes.jsx
+++ b/src/frontend-scripts/components/Gamenotes.jsx
@@ -22,6 +22,7 @@ class Gamenotes extends React.Component {
 
 	clearNotes = () => {
 		this.props.changeNotesValue('');
+		localStorage.setItem('GameNotes', '');
 	};
 
 	dismissNotes = () => {
@@ -46,6 +47,9 @@ class Gamenotes extends React.Component {
 	componentDidMount() {
 		document.body.addEventListener('dragover', dragOverFn);
 		document.body.addEventListener('drop', this.noteDrop);
+
+		const notes = localStorage.getItem('GameNotes');
+		this.props.changeNotesValue(notes == null ? '' : notes);
 	}
 
 	componentWillUnmount() {
@@ -65,6 +69,7 @@ class Gamenotes extends React.Component {
 	render() {
 		const notesChange = e => {
 			this.props.changeNotesValue(`${e.target.value}`);
+			localStorage.setItem('GameNotes', e.target.value);
 		};
 
 		return (


### PR DESCRIPTION
## Changes

Game notes are now stored in local storage, so they persist when the page reloads. (#1959)

## Tested Locally
- [X] This PR has been tested locally, and ensured to not cause any breaking changes
- [X] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

## Changelog
- [ ] Changelog Section below has been updated with Changelog entry
- [ ] This PR does not make a user-facing change

I'm not really sure if this is changelog-worthy, so I've left the section out.
