### PR TITLE
Profile.jsx & more improvements (Swal, jQuery, blacklist UI, bug fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
 		"snyk": "^1.189.0",
 		"socket.io": "2.0.3",
 		"socket.io-client": "2.0.3",
-		"sweetalert2": "9.10.9",
 		"tempy": "^1.0.1",
 		"yamljs": "^0.3.0"
 	},

--- a/src/frontend-scripts/components/App.jsx
+++ b/src/frontend-scripts/components/App.jsx
@@ -29,9 +29,7 @@ class TopLevelErrorBoundary extends React.Component {
 		this.state = {
 			error: null,
 			errorInfo: null,
-			feedbackResponseSwal: {},
-			sendAlertSwal: {},
-			toLobbySwal: {}
+			swal: {}
 		};
 	}
 
@@ -186,7 +184,7 @@ export class App extends React.Component {
 
 		socket.on('feedbackResponse', data => {
 			this.setState({
-				feedbackResponseSwal: {
+				swal: {
 					show: true,
 					title: data.message,
 					icon: data.status
@@ -293,7 +291,7 @@ export class App extends React.Component {
 
 		socket.on('sendAlert', data => {
 			this.setState({
-				sendAlertSwal: {
+				swal: {
 					show: true,
 					html: data
 				}
@@ -305,7 +303,7 @@ export class App extends React.Component {
 				// only eject the player from their current state if they are in the now-deleted game
 				window.location.hash = '#/';
 				this.setState({
-					toLobbySwal: {
+					swal: {
 						show: true,
 						title: 'The game you were previously in was deleted automatically.'
 					}
@@ -791,9 +789,7 @@ export class App extends React.Component {
 						})()}
 					</div>
 				</section>
-				<SweetAlert2 {...this.state.feedbackSwal} didClose={() => this.setState({ feedbackSwal: {} })} />
-				<SweetAlert2 {...this.state.sendAlertSwal} didClose={() => this.setState({ sendAlertSwal: {} })} />
-				<SweetAlert2 {...this.state.toLobbySwal} didClose={() => this.setState({ toLobbySwal: {} })} />
+				<SweetAlert2 {...this.state.swal} didClose={() => this.setState({ swal: {} })} />
 			</TopLevelErrorBoundary>
 		);
 	}

--- a/src/frontend-scripts/components/App.jsx
+++ b/src/frontend-scripts/components/App.jsx
@@ -19,7 +19,7 @@ import RightSidebar from './section-right/RightSidebar.jsx';
 import Menu from './menu/Menu.jsx';
 import DevHelpers from './DevHelpers.jsx';
 import '../../scss/style-dark.scss';
-import * as Swal from 'sweetalert2';
+import SweetAlert2 from 'react-sweetalert2';
 
 const select = state => state;
 
@@ -28,7 +28,10 @@ class TopLevelErrorBoundary extends React.Component {
 		super(props);
 		this.state = {
 			error: null,
-			errorInfo: null
+			errorInfo: null,
+			feedbackResponseSwal: {},
+			sendAlertSwal: {},
+			toLobbySwal: {}
 		};
 	}
 
@@ -182,7 +185,13 @@ export class App extends React.Component {
 		});
 
 		socket.on('feedbackResponse', data => {
-			Swal.fire(data.message, '', data.status);
+			this.setState({
+				feedbackResponseSwal: {
+					show: true,
+					title: data.message,
+					icon: data.status
+				}
+			});
 		});
 
 		socket.on('manualDisconnection', () => {
@@ -283,8 +292,11 @@ export class App extends React.Component {
 		});
 
 		socket.on('sendAlert', data => {
-			Swal.fire({
-				html: data
+			this.setState({
+				sendAlertSwal: {
+					show: true,
+					html: data
+				}
 			});
 		});
 
@@ -292,7 +304,12 @@ export class App extends React.Component {
 			if (window.location.hash === '/table/' + uid) {
 				// only eject the player from their current state if they are in the now-deleted game
 				window.location.hash = '#/';
-				Swal.fire('The game you were previously in was deleted automatically.');
+				this.setState({
+					toLobbySwal: {
+						show: true,
+						title: 'The game you were previously in was deleted automatically.'
+					}
+				});
 			}
 		});
 
@@ -774,6 +791,9 @@ export class App extends React.Component {
 						})()}
 					</div>
 				</section>
+				<SweetAlert2 {...this.state.feedbackSwal} didClose={() => this.setState({ feedbackSwal: {} })} />
+				<SweetAlert2 {...this.state.sendAlertSwal} didClose={() => this.setState({ sendAlertSwal: {} })} />
+				<SweetAlert2 {...this.state.toLobbySwal} didClose={() => this.setState({ toLobbySwal: {} })} />
 			</TopLevelErrorBoundary>
 		);
 	}

--- a/src/frontend-scripts/components/menu/Menu.jsx
+++ b/src/frontend-scripts/components/menu/Menu.jsx
@@ -23,8 +23,7 @@ class Menu extends React.Component {
 		super();
 
 		this.state = {
-			feedbackSwal: {},
-			loginSwal: {}
+			swal: {}
 		};
 	}
 
@@ -233,7 +232,7 @@ class Menu extends React.Component {
 									onClick={() => {
 										if (userInfo.userName) {
 											this.setState({
-												feedbackSwal: {
+												swal: {
 													show: true,
 													allowOutsideClick: false,
 													title: 'Feedback',
@@ -250,7 +249,7 @@ class Menu extends React.Component {
 											});
 										} else {
 											this.setState({
-												loginSwal: {
+												swal: {
 													show: true,
 													icon: 'error',
 													title: 'You must log in to submit feedback!'
@@ -448,7 +447,7 @@ class Menu extends React.Component {
 					</section>
 				</div>
 				<SweetAlert2
-					{...this.state.feedbackSwal}
+					{...this.state.swal}
 					onConfirm={result => {
 						if (result.value) {
 							socket.emit('feedbackForm', {
@@ -456,9 +455,8 @@ class Menu extends React.Component {
 							});
 						}
 					}}
-					didClose={() => this.setState({ feedbackSwal: {} })}
+					didClose={() => this.setState({ swal: {} })}
 				/>
-				<SweetAlert2 {...this.state.loginSwal} didClose={() => this.setState({ feedbackSwal: {} })} />
 			</div>
 		);
 	}

--- a/src/frontend-scripts/components/menu/Menu.jsx
+++ b/src/frontend-scripts/components/menu/Menu.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { viewPatchNotes } from '../../actions/actions';
 import { Popup } from 'semantic-ui-react';
 import SweetAlert2 from 'react-sweetalert2';
-// import * as Swal from 'sweetalert2';
 import socket from '../../socket';
 
 const mapStateToProps = ({ version }) => ({ version });

--- a/src/frontend-scripts/components/menu/Menu.jsx
+++ b/src/frontend-scripts/components/menu/Menu.jsx
@@ -3,7 +3,8 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { viewPatchNotes } from '../../actions/actions';
 import { Popup } from 'semantic-ui-react';
-import * as Swal from 'sweetalert2';
+import SweetAlert2 from 'react-sweetalert2';
+// import * as Swal from 'sweetalert2';
 import socket from '../../socket';
 
 const mapStateToProps = ({ version }) => ({ version });
@@ -21,6 +22,11 @@ const mapDispatchToProps = dispatch => ({
 class Menu extends React.Component {
 	constructor() {
 		super();
+
+		this.state = {
+			feedbackSwal: {},
+			loginSwal: {}
+		};
 	}
 
 	componentDidMount() {
@@ -227,30 +233,29 @@ class Menu extends React.Component {
 								<a
 									onClick={() => {
 										if (userInfo.userName) {
-											Swal.fire({
-												allowOutsideClick: false,
-												title: 'Feedback',
-												html:
-													'Please enter your feedback here. Reporting players and other time-sensitive moderation issues should go to #mod-support on our Discord.',
-												input: 'textarea',
-												inputAttributes: {
-													maxlength: 1900
-												},
-												confirmButtonText: 'Submit',
-												showCancelButton: true,
-												cancelButtonText: 'Cancel'
-											}).then(result => {
-												if (result.value) {
-													// result.value holds the feedback
-													socket.emit('feedbackForm', {
-														feedback: result.value
-													});
+											this.setState({
+												feedbackSwal: {
+													show: true,
+													allowOutsideClick: false,
+													title: 'Feedback',
+													html:
+														'Please enter your feedback here. Reporting players and other time-sensitive moderation issues should go to #mod-support on our Discord.',
+													input: 'textarea',
+													inputAttributes: {
+														maxlength: 1900
+													},
+													confirmButtonText: 'Submit',
+													showCancelButton: true,
+													cancelButtonText: 'Cancel'
 												}
 											});
 										} else {
-											Swal.fire({
-												icon: 'error',
-												title: 'You must log in to submit feedback!'
+											this.setState({
+												loginSwal: {
+													show: true,
+													icon: 'error',
+													title: 'You must log in to submit feedback!'
+												}
 											});
 										}
 									}}
@@ -443,6 +448,18 @@ class Menu extends React.Component {
 						</div>
 					</section>
 				</div>
+				<SweetAlert2
+					{...this.state.feedbackSwal}
+					onConfirm={result => {
+						if (result.value) {
+							socket.emit('feedbackForm', {
+								feedback: result.value
+							});
+						}
+					}}
+					didClose={() => this.setState({ feedbackSwal: {} })}
+				/>
+				<SweetAlert2 {...this.state.loginSwal} didClose={() => this.setState({ feedbackSwal: {} })} />
 			</div>
 		);
 	}

--- a/src/frontend-scripts/components/section-main/Creategame.jsx
+++ b/src/frontend-scripts/components/section-main/Creategame.jsx
@@ -4,7 +4,7 @@ import Select from 'react-select';
 import { Range } from 'rc-slider';
 import blacklistedWords from '../../../../iso/blacklistwords';
 import PropTypes from 'prop-types';
-import * as Swal from 'sweetalert2';
+import SweetAlert2 from 'react-sweetalert2';
 
 export default class Creategame extends React.Component {
 	constructor(props) {
@@ -60,7 +60,8 @@ export default class Creategame extends React.Component {
 				deckState: { lib: 6, fas: 11 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
 				trackState: { lib: 0, fas: 0 },
 				fasCanShootHit: false
-			}
+			},
+			userBannedSwal: {}
 		};
 	}
 
@@ -1033,7 +1034,12 @@ export default class Creategame extends React.Component {
 		if (this.state.containsBadWord) {
 			return;
 		} else if (userInfo.gameSettings && userInfo.gameSettings.unbanTime && new Date(userInfo.gameSettings.unbanTime) > new Date()) {
-			Swal.fire('Sorry, this service is currently unavailable.');
+			this.setState({
+				userBannedSwal: {
+					show: true,
+					html: 'Sorry, this service is currently unavailable.'
+				}
+			});
 		} else {
 			const excludedPlayerCount = this.state.checkedSliderValues.map((el, index) => (el ? null : index + 5)).filter(el => el);
 			const data = {
@@ -2291,6 +2297,7 @@ export default class Creategame extends React.Component {
 						Create game
 					</div>
 				</div>
+				<SweetAlert2 didClose={() => this.setState({ userBannedSwal: {} })} />
 			</section>
 		);
 	}

--- a/src/frontend-scripts/components/section-main/Creategame.jsx
+++ b/src/frontend-scripts/components/section-main/Creategame.jsx
@@ -61,7 +61,7 @@ export default class Creategame extends React.Component {
 				trackState: { lib: 0, fas: 0 },
 				fasCanShootHit: false
 			},
-			userBannedSwal: {}
+			swal: {}
 		};
 	}
 
@@ -1035,7 +1035,7 @@ export default class Creategame extends React.Component {
 			return;
 		} else if (userInfo.gameSettings && userInfo.gameSettings.unbanTime && new Date(userInfo.gameSettings.unbanTime) > new Date()) {
 			this.setState({
-				userBannedSwal: {
+				swal: {
 					show: true,
 					html: 'Sorry, this service is currently unavailable.'
 				}
@@ -2297,7 +2297,7 @@ export default class Creategame extends React.Component {
 						Create game
 					</div>
 				</div>
-				<SweetAlert2 didClose={() => this.setState({ userBannedSwal: {} })} />
+				<SweetAlert2 {...this.state.swal} didClose={() => this.setState({ swal: {} })} />
 			</section>
 		);
 	}

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -9,7 +9,6 @@ import { loadReplay, toggleNotes, updateUser } from '../../actions/actions';
 import { PLAYERCOLORS, getBadWord, getNumberWithOrdinal } from '../../constants';
 import { renderEmotesButton, processEmotes } from '../../emotes';
 import SweetAlert2 from 'react-sweetalert2';
-// import * as Swal from 'sweetalert2';
 
 const mapDispatchToProps = dispatch => ({
 	loadReplay: summary => dispatch(loadReplay(summary)),

--- a/src/frontend-scripts/components/section-main/Gamechat.jsx
+++ b/src/frontend-scripts/components/section-main/Gamechat.jsx
@@ -1192,20 +1192,17 @@ class Gamechat extends React.Component {
 					}
 					break;
 				case 'modDeleteGameConfirm':
-					console.log('confirm', result);
-					setTimeout(() => {
-						if (result.value) {
-							this.setState({
-								swalAction: '',
-								swal: {},
-								delSwal: {
-									show: true,
-									title: 'Enter a reason for deleting this game, leave blank if dead',
-									input: 'text'
-								}
-							});
-						}
-					}, 100);
+					if (result.value) {
+						this.setState({
+							swalAction: '',
+							swal: {},
+							delSwal: {
+								show: true,
+								title: 'Enter a reason for deleting this game, leave blank if dead',
+								input: 'text'
+							}
+						});
+					}
 					break;
 				default:
 					break;
@@ -1773,7 +1770,6 @@ class Gamechat extends React.Component {
 				<SweetAlert2
 					{...this.state.delSwal}
 					onConfirm={result => {
-						console.log('reason', result);
 						if (result.isConfirmed) {
 							const reason = result.value === '' ? 'Dead' : result.value;
 							modDeleteGame(reason);

--- a/src/frontend-scripts/components/section-main/Players.jsx
+++ b/src/frontend-scripts/components/section-main/Players.jsx
@@ -21,8 +21,7 @@ class Players extends React.Component {
 		playerNotes: [],
 		playerNoteSeatEnabled: false,
 		reportLength: 0,
-		banSwal: {},
-		killSwal: {},
+		swal: {},
 		temporaryIndex: 0
 	};
 
@@ -103,7 +102,7 @@ class Players extends React.Component {
 				if (!gameSettings.disableKillConfirmation) {
 					this.setState({
 						temporaryIndex: index,
-						killSwal: {
+						swal: {
 							show: true,
 							title: `Are you sure you want to execute {${index + 1}} ${name}?`,
 							showCancelButton: true,
@@ -479,7 +478,7 @@ class Players extends React.Component {
 				$(this.incognitoModal).modal('show');
 			} else if (userInfo.gameSettings.unbanTime && new Date(userInfo.gameSettings.unbanTime) > new Date()) {
 				this.setState({
-					banSwal: {
+					swal: {
 						show: true,
 						title: 'Sorry, this service is currently unavailable.'
 					}
@@ -669,9 +668,8 @@ class Players extends React.Component {
 					isReplay={isReplay}
 					deckShown={this.props.deckShown}
 				/>
-				<SweetAlert2 {...this.state.banSwal} didClose={() => this.setState({ banSwal: {} })} />
 				<SweetAlert2
-					{...this.state.killSwal}
+					{...this.state.swal}
 					onConfirm={result => {
 						if (result.value) {
 							this.props.socket.emit('selectedPlayerToExecute', {
@@ -680,7 +678,7 @@ class Players extends React.Component {
 							});
 						}
 					}}
-					didClose={() => this.setState({ killSwal: {} })}
+					didClose={() => this.setState({ swal: {} })}
 				/>
 			</section>
 		);

--- a/src/frontend-scripts/components/section-main/Profile.jsx
+++ b/src/frontend-scripts/components/section-main/Profile.jsx
@@ -701,7 +701,7 @@ class ProfileWrapper extends React.Component {
 											{this.props?.profile?._id === this.props?.userInfo?.userName && (
 												<td>
 													<button
-														className="ui red button"
+														className="ui blacklist button"
 														onClick={() => {
 															const { gameSettings } = this.props.userInfo;
 															gameSettings.blacklist.splice(getBlacklistIndex(userName, gameSettings.blacklist), 1);
@@ -713,7 +713,7 @@ class ProfileWrapper extends React.Component {
 															}, 500);
 														}}
 													>
-														Delete
+														<span className="ui blacklist text">Delete</span>
 													</button>
 												</td>
 											)}

--- a/src/frontend-scripts/components/section-main/Profile.jsx
+++ b/src/frontend-scripts/components/section-main/Profile.jsx
@@ -5,7 +5,6 @@ import React from 'react'; // eslint-disable-line no-unused-vars
 import PropTypes from 'prop-types';
 import cn from 'classnames';
 import { PLAYERCOLORS } from '../../constants';
-import Swal from 'sweetalert2';
 import SweetAlert2 from 'react-sweetalert2';
 import { Dropdown } from 'semantic-ui-react';
 import moment from 'moment';
@@ -28,7 +27,8 @@ class ProfileWrapper extends React.Component {
 			openTime: Date.now(),
 			badgeSort: 'badge',
 			profileSearchValue: '',
-			blacklistSwal: {}
+			blacklistSwal: {},
+			badgeSwal: {}
 		};
 	}
 
@@ -38,7 +38,7 @@ class ProfileWrapper extends React.Component {
 		let updatedState = null;
 
 		if (name !== newName) {
-			updatedState = { ...updatedState, profileUser: newName, blacklistSwal: {} };
+			updatedState = { ...updatedState, profileUser: newName, blacklistSwal: {}, badgeSwal: {} };
 		}
 		return updatedState;
 	}
@@ -246,14 +246,18 @@ class ProfileWrapper extends React.Component {
 							key={x.id}
 							height={50}
 							onClick={() =>
-								Swal.fire({
-									title: x.title,
-									text: `${x.text || ''} Earned: ${moment(x.dateAwarded).format('MM/DD/YYYY HH:mm')}.`,
-									imageUrl: `../images/badges/${x.id.startsWith('eloReset') ? 'eloReset' : x.id}.png`,
-									imageWidth: 100
+								this.setState({
+									badgeSwal: {
+										show: true,
+										title: x.title,
+										html: `${x.text || ''} Earned: ${moment(x.dateAwarded).format('MM/DD/YYYY HH:mm')}.`,
+										imageUrl: `../images/badges/${x.id.startsWith('eloReset') ? 'eloReset' : x.id}.png`,
+										imageWidth: 100
+									}
 								})
 							}
 						/>
+						<SweetAlert2 {...this.state.badgeSwal} didClose={() => this.setState({ badgeSwal: {} })} />
 						{x.id.startsWith('eloReset') ? (
 							<p style={{ position: 'relative', top: '50%', transform: 'translateY(-100%)', display: 'inline-block' }} key={x.id + 'p'}>
 								{x.id.substring(8)}
@@ -433,7 +437,7 @@ class ProfileWrapper extends React.Component {
 		this.setState({
 			blacklistSwal: {
 				show: true,
-				title: this.props?.profile?.blacklist ? "Player's Blacklist" : 'Your Blacklist',
+				title: this.props?.profile?._id !== this.props?.userInfo?.userName ? "Player's Blacklist" : 'Your Blacklist',
 				width: '800px'
 			}
 		});
@@ -652,10 +656,6 @@ class ProfileWrapper extends React.Component {
 			}
 		};
 
-		const closeBlacklistSwal = () => {
-			this.setState({ blacklistSwal: {} });
-		};
-
 		const children = (() => {
 			switch (profile.status) {
 				case 'INITIAL':
@@ -674,7 +674,7 @@ class ProfileWrapper extends React.Component {
 					<i className="remove icon" />
 				</a>
 				{children}
-				<SweetAlert2 {...this.state.blacklistSwal} didClose={closeBlacklistSwal}>
+				<SweetAlert2 {...this.state.blacklistSwal} didClose={() => this.setState({ blacklistSwal: {} })}>
 					{blacklist && (
 						<table className="ui single line table">
 							<thead>
@@ -692,7 +692,7 @@ class ProfileWrapper extends React.Component {
 									return (
 										<tr key={userName} className={`blacklist-${userName}`}>
 											<td>
-												<a href={`/game/#/profile/${blacklistInfo.username}`} onClick={closeBlacklistSwal}>
+												<a href={`/game/#/profile/${blacklistInfo.username}`} onClick={() => this.setState({ blacklistSwal: {} })}>
 													{blacklistInfo.username}
 												</a>
 											</td>

--- a/src/frontend-scripts/components/section-main/Profile.jsx
+++ b/src/frontend-scripts/components/section-main/Profile.jsx
@@ -724,7 +724,6 @@ class ProfileWrapper extends React.Component {
 						</table>
 					)}
 				</SweetAlert2>
-				{/* </div> */}
 			</section>
 		);
 	}

--- a/src/frontend-scripts/components/section-main/Signups.jsx
+++ b/src/frontend-scripts/components/section-main/Signups.jsx
@@ -1,13 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import * as Swal from 'sweetalert2';
+import SweetAlert2 from 'react-sweetalert2';
 
 let signupType = 'getSignups';
 
 const Signups = ({ socket }) => {
 	const [signuplog, updateSignuplog] = useState([]);
 	const [logSort, updateLogSort] = useState({ type: 'date', direction: 'descending' });
+	const [reportDiscordSwal, updateReportDiscordSwal] = useState({});
 	useEffect(() => {
 		socket.emit(signupType);
 
@@ -117,7 +118,10 @@ const Signups = ({ socket }) => {
 									<td
 										onClick={() => {
 											if (report.email.indexOf('#') !== -1) {
-												Swal.fire('Discord ID: ' + report.oauthID);
+												updateReportDiscordSwal({
+													show: true,
+													title: 'Discord ID: ' + report.oauthID
+												});
 											}
 										}}
 										style={{ cursor: `${report.email.indexOf('#') !== -1 ? 'pointer' : ''}` }}
@@ -164,6 +168,7 @@ const Signups = ({ socket }) => {
 				Toggle Signup Type
 			</span>
 			{renderSignupsLog()}
+			<SweetAlert2 {...reportDiscordSwal} didClose={() => updateReportDiscordSwal({})} />
 		</section>
 	);
 };

--- a/src/frontend-scripts/components/section-main/Tracks.jsx
+++ b/src/frontend-scripts/components/section-main/Tracks.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { Popup } from 'semantic-ui-react';
 import playSound from '../reusable/playSound.js';
 import moment from 'moment';
-import * as Swal from 'sweetalert2';
+import SweetAlert2 from 'react-sweetalert2';
 
 class Tracks extends React.Component {
 	constructor() {
@@ -15,7 +15,8 @@ class Tracks extends React.Component {
 			minutes: 0,
 			seconds: 0,
 			timedMode: false,
-			showTimer: false
+			showTimer: false,
+			swal: {}
 		};
 	}
 
@@ -631,7 +632,12 @@ class Tracks extends React.Component {
 		const showDate = () => {
 			if (gameInfo && gameInfo.general && gameInfo.general.date) {
 				// field only exists in replays
-				Swal.fire(`This game was played on ${moment(gameInfo.general.date)}.`);
+				this.setState({
+					swal: {
+						show: true,
+						title: `This game was played on ${moment(gameInfo.general.date)}.`
+					}
+				});
 			}
 		};
 
@@ -716,6 +722,7 @@ class Tracks extends React.Component {
 					</div>
 					{renderElectionTracker()}
 				</section>
+				<SweetAlert2 {...this.state.swal} didClose={() => this.setState({ swal: {} })} />
 			</section>
 		);
 	}

--- a/src/frontend-scripts/components/section-main/replay/Replay.jsx
+++ b/src/frontend-scripts/components/section-main/replay/Replay.jsx
@@ -14,7 +14,7 @@ import ReplayControls from './ReplayControls.jsx';
 import TrackPieces from './TrackPieces.jsx';
 import socket from '../../../socket';
 import PropTypes from 'prop-types';
-import * as Swal from 'sweetalert2';
+import SweetAlert2 from 'react-sweetalert2';
 
 const mapStateToProps = ({ replay, userInfo }) => ({
 	replay,
@@ -217,7 +217,8 @@ class ReplayWrapper extends React.Component {
 			requestedData: false,
 			deckShown: false,
 			legacyReplay: true,
-			gameData: {}
+			gameData: {},
+			swal: {}
 		};
 	}
 
@@ -275,7 +276,13 @@ class ReplayWrapper extends React.Component {
 
 		const toggleDeck = () => {
 			if (this.state.legacyReplay) {
-				Swal.fire('', 'You cannot load deck information for a legacy replay.', 'error');
+				this.setState({
+					swal: {
+						show: true,
+						html: 'You cannot load deck information for a legacy replay',
+						icon: 'error'
+					}
+				});
 			}
 
 			this.setState({
@@ -335,6 +342,7 @@ class ReplayWrapper extends React.Component {
 					Exit Replay
 				</button>
 				{children}
+				<SweetAlert2 {...this.state.swal} didClose={() => this.setState({ swal: {} })} />
 			</section>
 		);
 	}

--- a/src/frontend-scripts/components/section-main/tracks.test.js
+++ b/src/frontend-scripts/components/section-main/tracks.test.js
@@ -9,7 +9,8 @@ describe('Tracks', () => {
 			minutes: 0,
 			seconds: 0,
 			timedMode: false,
-			showTimer: false
+			showTimer: false,
+			swal: {}
 		};
 
 		const component = shallow(<Tracks gameInfo={{ general: {}, publicPlayersState: [], cardFlingerState: [], trackState: {}, gameState: {} }} />);

--- a/src/scss/style-dark.scss
+++ b/src/scss/style-dark.scss
@@ -824,8 +824,13 @@
 	color: var(--theme-primary);
 }
 
+.ui.blacklist,
 .ui.pronouns {
 	color: var(--theme-primary);
+}
+
+.ui.blacklist.text {
+	color: var(--theme-text-1);
 }
 
 .ui.primary.buttons .button:hover,


### PR DESCRIPTION
## Changes

Overhauled the blacklist modal, removed jquery, made it into a react-sweetalert2 modal, removed some unused or unneeded code, updates existing sweet alert modals in `profile.jsx`, and fixes issue with AEM not seeing the delete button on their blacklists in the `Profile.jsx` file. Switched all Swal modals to react-sweetalert2 modals.

## Screenshots

![image](https://user-images.githubusercontent.com/38539079/160720189-02275c62-9e41-4bc2-88c7-d79fc266a908.png)

---

## Tested Locally
- [X] This PR has been tested locally, and ensured to not cause any breaking changes

## Tests
- [X] This PR does not require tests

## Changelog
Not applicable -- lumped into past blacklist UI changes.

Check one, delete the other:
- [X] Bug Fix

Check one, delete the other:
- [X] Minor Change
