### PR TITLE
Disable the report button on admins/editors/moderators via the user popup menu

### DIFF
--- a/src/frontend-scripts/components/reusable/UserPopup.jsx
+++ b/src/frontend-scripts/components/reusable/UserPopup.jsx
@@ -270,7 +270,7 @@ const UserPopup = ({ socket, userInfo, gameInfo, userList, children, userName, p
 								</Button>
 							</List.Item>
 						)}
-						{!notVisible && !privateGame && (!isMe || (!gameStarted && blindMode)) && (
+						{!notVisible && !privateGame && !areTheyAEM && (!isMe || (!gameStarted && blindMode)) && (
 							<List.Item>
 								<List.Icon name="gavel" />
 								<List.Content>


### PR DESCRIPTION
## Changes

Removes the report button on admins/editors/moderators via the user popup menu.

## Screenshots

![-](https://i.imgur.com/m8bBLs7.png)
![-](https://i.imgur.com/7d9AxKT.png)

---

## Tested Locally
- [x] This PR has been tested locally, and ensured to not cause any breaking changes

## Tests
- [x] This PR does not require tests

## Changelog
- [x] Changelog Section below has been updated with Changelog entry

### Changelog Entry (delete this section if this PR does not need a changelog entry)

Check one, delete the other:
- [x] New Feature

Check one, delete the other:
- [x] Minor Change

**Changelog Headline**: Removed Report option from Admins/Editors/Moderators

**Changelog Details**: Admins/Editors/Moderators may no longer be reported via the user popup menu.
