### PR TITLE
adds chat replacements for avalon sh gamemode

### DIFF
--- a/routes/socket/chatReplacements.js
+++ b/routes/socket/chatReplacements.js
@@ -79,5 +79,38 @@ module.exports.chatReplacements = [
 		aemCooldown: 15,
 		normalCooldown: 180,
 		normalGames: 50
+	},
+	{
+		id: 10,
+		regex: /^avalon.sh$/i,
+		replacement:
+			'ONLY FOR AVALON SH MODE: Avalon SH mode is a custom game mode that adds 3 new roles to the game: Percival, Merlin, and Morgana. Fascists also get a new win condition as after 5 liberal policies are enacted or Hilter is executed they can still try to kill Merlin to win.',
+		aemCooldown: 15,
+		normalCooldown: 180,
+		normalGames: 50
+	},
+	{
+		id: 11,
+		regex: /^p.ercival$/i,
+		replacement: 'ONLY FOR AVALON SH MODE: Percival is a liberal role that knows who Merlin and Morgana are, but not which is which.',
+		aemCooldown: 15,
+		normalCooldown: 180,
+		normalGames: 50
+	},
+	{
+		id: 12,
+		regex: /^m.erlin$/i,
+		replacement: 'ONLY FOR AVALON SH MODE: Merlin is a liberal role that knows who the fascists are, but not which of them is Hitler.',
+		aemCooldown: 15,
+		normalCooldown: 180,
+		normalGames: 50
+	},
+	{
+		id: 13,
+		regex: /^m.organa$/i,
+		replacement: "ONLY FOR AVALON SH MODE: Morgana is a reg fascist role (can't be Hitler) that appears as possible Merlin to Percival.",
+		aemCooldown: 15,
+		normalCooldown: 180,
+		normalGames: 50
 	}
 ];


### PR DESCRIPTION
## Changes

 Added new text replacements (or dot commands if you prefer):
1. `avalon.sh` - explains differences in Avalon SH gamemode
2. `p.ercival` - explains Percival role in Avalon SH gamemode
3. `m.erlin` - explains Merlin role in Avalon SH gamemode
4. `m.organa` - explains Morgana role in Avalon SH gamemode

## Screenshots

These are effectively required for non-trivial changes, but appreciated for all.

![new text replacements for Avalon SH](https://cdn.discordapp.com/attachments/743816603283488779/1125458659103756370/image.png)
---

## Tested Locally
- [x] This PR makes a trivial change

## Tests
- [x] This PR does not require tests

## Changelog
- [x] Changelog Section below has been updated with Changelog entry

### Changelog Entry (delete this section if this PR does not need a changelog entry)

- [x] New Feature

- [x] Minor Change

**Changelog Headline**: Add 4 new Avalon SH related chat replacements

**Changelog Details**: Add Avalon SH chat replacements for a gamemode in general and each of the roles