### PR TITLE
Jaro32768 name darkened after being shot + removed icon from sidebar

### DIFF
--- a/src/frontend-scripts/components/section-main/Players.jsx
+++ b/src/frontend-scripts/components/section-main/Players.jsx
@@ -349,7 +349,9 @@ class Players extends React.Component {
 								classes = `${classes} ${publicPlayersState[i].nameStatus}`;
 							}
 
-							if (publicPlayersState[i].leftGame) {
+							if (publicPlayersState && Object.keys(publicPlayersState).length && publicPlayersState[i].isDead && !gameState.isCompleted) {
+								classes = `${classes} isDead`;
+							} else if (publicPlayersState[i].leftGame) {
 								classes = `${classes} leftgame`;
 							} else if (!publicPlayersState[i].connected) {
 								classes = `${classes} disconnected`;

--- a/src/frontend-scripts/components/section-right/Playerlist.jsx
+++ b/src/frontend-scripts/components/section-right/Playerlist.jsx
@@ -206,9 +206,10 @@ class Playerlist extends React.Component {
 	renderPlayerlist() {
 		if (Object.keys(this.props.userList).length) {
 			const { list } = this.props.userList;
-			const { userInfo } = this.props;
+			const { userInfo, gameInfo } = this.props;
 			const { expandInfo } = this.state;
 			const { gameSettings } = userInfo;
+			const { gameState, publicPlayersState } = gameInfo;
 			const w =
 				gameSettings && gameSettings.disableSeasonal
 					? this.state.userListFilter === 'all'
@@ -295,7 +296,17 @@ class Playerlist extends React.Component {
 				const renderStatus = () => {
 					const status = user.status;
 
-					if (!status || status.type === 'none') {
+					let isDead = false;
+					if (publicPlayersState)
+						publicPlayersState.forEach(playerState => {
+							if (playerState.userName === user.userName) {
+								if (playerState.isDead && !gameState.isCompleted) {
+									isDead = true;
+								}
+							}
+						});
+
+					if (!status || status.type === 'none' || isDead) {
 						return <i className={'status unclickable icon'} />;
 					} else {
 						const iconClasses = classnames(

--- a/src/frontend-scripts/components/section-right/RightSidebar.jsx
+++ b/src/frontend-scripts/components/section-right/RightSidebar.jsx
@@ -11,7 +11,7 @@ const RightSidebar = props => {
 
 	return (
 		<section className={classes} id={'playerlist'}>
-			{!props.forceMounted && <Playerlist userInfo={props.userInfo} userList={props.userList} socket={props.socket} />}
+			{!props.forceMounted && <Playerlist userInfo={props.userInfo} userList={props.userList} socket={props.socket} gameInfo={props.gameInfo} />}
 			<Generalchat
 				gameInfo={props.gameInfo}
 				socket={props.socket}

--- a/src/scss/players.scss
+++ b/src/scss/players.scss
@@ -360,7 +360,8 @@ $eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (190
 		.card-container.flipped {
 			transform: rotateY(180deg);
 		}
-		.player-number.leftgame {
+		.player-number.leftgame,
+		.player-number.isDead {
 			opacity: 0.3;
 		}
 		.player-number.disconnected {


### PR DESCRIPTION
## Changes

 After someone gets shot they name gets darkened (same as if they leave) to prevent people getting influenced by dead people leaving. Their icon from right sidebar also gets removed for seated players (people not seated in the game can still see a location of the dead person on the sidebar).

## Screenshots
![name darkened after being shot and removed icon from sidebar](https://media.discordapp.net/attachments/743816603283488779/1125532988239790082/image.png?width=1440&height=451)

---

## Tested Locally
- [x] This PR has been tested locally, and ensured to not cause any breaking changes

## Tests
- [x] This PR does not require tests

## Changelog
- [x] Changelog Section below has been updated with Changelog entry

### Changelog Entry (delete this section if this PR does not need a changelog entry)

- [x] New Feature

- [x] Minor Change

**Changelog Headline**: Dead players no longer show as present in the lobby.

**Changelog Details**: Dead players get their name darkened and they get icon removed from sidebar. People not involved in the lobby can still see their icon in the sidebar.
