### PR TITLE
Expanding custom game sliders

### DIFF
--- a/routes/socket/user-events.js
+++ b/routes/socket/user-events.js
@@ -666,8 +666,8 @@ module.exports.handleAddNewGame = (socket, passport, data) => {
 		if (!(data.customGameSettings.fascistCount >= 1) || data.customGameSettings.fascistCount + 1 > playerCounts[0] / 2) return;
 
 		// Ensure standard victory conditions can be met for both teams.
-		if (!(data.customGameSettings.deckState.lib >= 5) || data.customGameSettings.deckState.lib > 8) return;
-		if (!(data.customGameSettings.deckState.fas >= 6) || data.customGameSettings.deckState.fas > 19) return;
+		if (!(data.customGameSettings.deckState.lib >= 5) || data.customGameSettings.deckState.lib > 10) return;
+		if (!(data.customGameSettings.deckState.fas >= 6) || data.customGameSettings.deckState.fas > 20) return;
 
 		// Roundabout way of checking for null/undefined but not 0.
 		if (!(data.customGameSettings.trackState.lib >= 0) || data.customGameSettings.trackState.lib > 4) return;

--- a/src/frontend-scripts/components/section-main/Creategame.jsx
+++ b/src/frontend-scripts/components/section-main/Creategame.jsx
@@ -1587,22 +1587,22 @@ export default class Creategame extends React.Component {
 							<h4 className="ui header">Liberal policies</h4>
 							<Range
 								min={5}
-								max={8}
+								max={10}
 								defaultValue={[6]}
 								onChange={this.sliderDeckLib}
 								value={[this.state.customGameSettings.deckState.lib]}
-								marks={{ 5: '5', 6: '6', 7: '7', 8: '8' }}
+								marks={{ 5: '5', 6: '6', 7: '7', 8: '8' , 9: '9', 10: '10' }}
 							/>
 						</div>
 						<div className="eight wide column">
 							<h4 className="ui header">Fascist policies</h4>
 							<Range
 								min={10}
-								max={19}
+								max={20}
 								defaultValue={[12]}
 								onChange={this.sliderDeckFas}
 								value={[this.state.customGameSettings.deckState.fas]}
-								marks={{ 10: '10', 11: '', 12: '', 13: '13', 14: '', 15: '', 16: '16', 17: '', 18: '', 19: '19' }}
+								marks={{ 10: '10', 11: '', 12: '', 13: '13', 14: '', 15: '', 16: '16', 17: '', 18: '', 19: '19' , 20: '20' }}
 							/>
 						</div>
 					</div>

--- a/src/frontend-scripts/components/section-main/Creategame.jsx
+++ b/src/frontend-scripts/components/section-main/Creategame.jsx
@@ -1599,10 +1599,10 @@ export default class Creategame extends React.Component {
 							<Range
 								min={10}
 								max={20}
-								defaultValue={[12]}
+								defaultValue={[11]}
 								onChange={this.sliderDeckFas}
 								value={[this.state.customGameSettings.deckState.fas]}
-								marks={{ 10: '10', 11: '', 12: '', 13: '13', 14: '', 15: '', 16: '16', 17: '', 18: '', 19: '19' , 20: '20' }}
+								marks={{ 10: '10', 11: '', 12: '', 13: '13', 14: '', 15: '', 16: '', 17: '17', 18: '', 19: '' , 20: '20' }}
 							/>
 						</div>
 					</div>


### PR DESCRIPTION
## Changes

This expands the allowed amount of Custom Game liberal policies to 10, and the amount of Custom Game fascist policies to 20

## Screenshots
<img width="444" alt="Screen Shot 2023-07-10 at 10 34 10 AM" src="https://github.com/cozuya/secret-hitler/assets/49939932/afa73bdc-23c3-46a4-8280-a0abf612ad18">

<img width="502" alt="Screen Shot 2023-07-10 at 10 33 54 AM" src="https://github.com/cozuya/secret-hitler/assets/49939932/1b80d63c-6c75-4b04-8996-6760687a7ff6">


---

## Tested Locally
- [X] This PR has been tested locally, and ensured to not cause any breaking changes
- [ ] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [X] This PR does not require tests

## Changelog
- [ ] Changelog Section below has been updated with Changelog entry
- [ ] This PR does not make a user-facing change

### Changelog Entry (delete this section if this PR does not need a changelog entry)

Check one, delete the other:
- [X] New Feature
- [ ] Bug Fix

Check one, delete the other:
- [ ] Major Change
- [X] Minor Change

**Changelog Headline**: Custom Game Deck Expansion!

**Changelog Details**: The allowed amount of liberal cards in Custom Games has been expanded to 10, and the allowed amount of fascist cards has been expanded to 20.
