### PR TITLE
Prevent uploading a WebP cardback from causing an unhandled error

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -487,7 +487,7 @@ module.exports = () => {
 						});
 					} else {
 						ProcessImage(username, raw, (resp, err) => {
-							res.json({ message: err || resp });
+							res.json({ message: err ? err.message : '' || resp });
 						});
 					}
 				})

--- a/src/frontend-scripts/components/section-main/Settings.jsx
+++ b/src/frontend-scripts/components/section-main/Settings.jsx
@@ -778,7 +778,7 @@ class Settings extends React.Component {
 			})
 				.then(data => {
 					this.setState({
-						cardbackUploadStatus: data.message,
+						cardbackUploadStatus: data.message ? data.message.toString() : '',
 						isUploaded: data.message === 'Image uploaded successfully.' ? this.state.preview : '',
 						preview: ''
 					});


### PR DESCRIPTION
## Changes

Please describe the changes made in the pull request here.

While I was investigating the cardback upload errors, I came across a different error that happens if you upload WebP image files (and potentially other image files in an unknown format).

I changed the callback to use `err.message` instead of `err`, since React doesn't like rendering objects (and just in case, I toString() the message from the server).

## Screenshots

These are effectively required for non-trivial changes, but appreciated for all.

Currently, uploading a webp image results in the following error message:
![image](https://github.com/user-attachments/assets/3cdc443d-7afd-425f-90d2-e68828b5c1ad)

With this change, it shows a more informative error message:
![image](https://github.com/user-attachments/assets/649b551d-afa2-4439-9300-aeed62835482)

---

## Tested Locally
- [ ] This PR has been tested locally, and ensured to not cause any breaking changes
- [x] This PR makes a trivial change

## Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests

## Changelog
- [ ] Changelog Section below has been updated with Changelog entry
- [x] This PR does not make a user-facing change
