### PR TITLE
Change default timer length

### DIFF
--- a/src/frontend-scripts/components/section-main/Creategame.jsx
+++ b/src/frontend-scripts/components/section-main/Creategame.jsx
@@ -40,7 +40,7 @@ export default class Creategame extends React.Component {
 			blindMode: false,
 			timedMode: false,
 			isVerifiedOnly: props.userInfo.verified && !isRainbow,
-			timedSliderValue: [120],
+			timedSliderValue: [180],
 			customGameSliderValue: [7],
 			eloSliderValue: [1600],
 			xpSliderValue: [0],


### PR DESCRIPTION
Changed the default timer length to 3 minutes, which seems to be the preferred length. The slider has always been a little finicky, as well as the text input. Just a QoL update.