### PR TITLE
revised #2011

### DIFF
--- a/src/scss/players.scss
+++ b/src/scss/players.scss
@@ -191,7 +191,7 @@ $eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (190
 		.card-container {
 			width: 100%;
 			height: 95px;
-			top: 100px;
+			top: 100%;
 			left: 0;
 			transition-duration: 1s;
 			transition-property: transform, top;
@@ -366,8 +366,7 @@ $eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (190
 			}
 		}
 		.card-container.showing {
-			// prevents 1px gap showing below card
-			top: 1px;
+			top: 0;
 		}
 		.card-container.flipped {
 			transform: rotateY(180deg);


### PR DESCRIPTION
## Changes

- Small revision to "Changed UI to not have the crown push down ballets #2011" that fixes the small gap between the glow and ballet.

## Screenshots
Before:
<img width="439" height="131" alt="image" src="https://github.com/user-attachments/assets/733da92d-8770-42c3-a659-b4262463b7db" />
After:
<img width="430" height="126" alt="Screenshot 2026-02-16 at 5 38 54 PM" src="https://github.com/user-attachments/assets/76269e22-6b70-4878-88d9-517479d5a982" />
<img width="430" height="190" alt="Screenshot 2026-02-16 at 6 06 07 PM" src="https://github.com/user-attachments/assets/fb819aff-1e39-4108-8f0e-14b96e0a7da2" />