### PR TITLE
AvalonSH dot commands (chat replacements)

### DIFF
--- a/routes/socket/chatReplacements.js
+++ b/routes/socket/chatReplacements.js
@@ -79,5 +79,38 @@ module.exports.chatReplacements = [
 		aemCooldown: 15,
 		normalCooldown: 180,
 		normalGames: 50
+	},
+	{
+		id: 10,
+		regex: /^a.valon$/i,
+		replacement:
+			'In Avalon SH fascists get a new win condition - after 5 liberal policies are enacted or Hilter is executed, Hitler can try to guess Merlin to win. Lobby creator can also add Percival and Morgana while creating a lobby.',
+		aemCooldown: 15,
+		normalCooldown: 180,
+		normalGames: 50
+	},
+	{
+		id: 11,
+		regex: /^p.ercival$/i,
+		replacement: 'Percival is a liberal role that knows who Merlin and Morgana are, but not which is which.',
+		aemCooldown: 15,
+		normalCooldown: 180,
+		normalGames: 50
+	},
+	{
+		id: 12,
+		regex: /^m.erlin$/i,
+		replacement: 'Merlin is a liberal role that knows who the fascists are, but does not know their specific roles.',
+		aemCooldown: 15,
+		normalCooldown: 180,
+		normalGames: 50
+	},
+	{
+		id: 13,
+		regex: /^m.organa$/i,
+		replacement: "Morgana is a fascist role (can't be Hitler) that appears as possible Merlin candidate to Percival.",
+		aemCooldown: 15,
+		normalCooldown: 180,
+		normalGames: 50
 	}
 ];


### PR DESCRIPTION
## Changes

Added 4 more chat dot commands to shortly explain the general idea of the gamemode and the roles it is adding. This way it is easier to explain the gamemode to players who have never played it before.

`a.valon` - In Avalon SH fascists get a new win condition - after 5 liberal policies are enacted or Hilter is executed, Hitler can try to guess Merlin to win. Lobby creator can also add Percival and Morgana while creating a lobby.
`m.erlin` - Merlin is a liberal role that knows who the fascists are, but does not know their specific roles.
`p.ercival` - Percival is a liberal role that knows who Merlin and Morgana are, but not which is which.
`m.organa` - Morgana is a fascist role (can't be Hitler) that appears as possible Merlin candidate to Percival.

## Screenshots

<img width="1271" height="155" alt="image" src="https://github.com/user-attachments/assets/dc503ed3-e6e7-4d8c-8907-3b6c7be9a26b" />

## Tested Locally
- [x] This PR makes a trivial change

## Tests
- [x] This PR does not require tests

- [x] New Feature

- [x] Minor Change