### PR TITLE
Update outdated 50 xp / 50 games required messages

### DIFF
--- a/src/frontend-scripts/components/section-left/SidebarGame.jsx
+++ b/src/frontend-scripts/components/section-left/SidebarGame.jsx
@@ -82,7 +82,7 @@ const SidebarGame = ({ game, socket }) => {
 					<div
 						className={game.rainbowgame ? 'gamename rainbow' : 'gamename'}
 						title={
-							(game.rainbowgame ? 'Rainbow game - only players with 50+ XP can be seated in this game.' : 'Click here to enter this game table.') +
+							(game.rainbowgame ? 'Rainbow game - only players with 10+ XP can be seated in this game.' : 'Click here to enter this game table.') +
 							' Already in game: ' +
 							game.userNames.join(', ')
 						}

--- a/src/frontend-scripts/components/section-main/Main.jsx
+++ b/src/frontend-scripts/components/section-main/Main.jsx
@@ -184,7 +184,7 @@ export class Main extends React.Component {
 									<React.Fragment>
 										<h5>How do you get a cool player color or upload your own personal cardback?</h5>
 										<p>
-											Practice and Ranked games grant players Experience Points (XP). Gain 50 XP to attain "rainbow" status and have a color based off your ELO.
+											Practice and Ranked games grant players Experience Points (XP). Gain 10 XP to attain "rainbow" status and have a color based off your ELO.
 											Click on the info icon next to "Lobby" in the upper right corner to learn more. Games that grant ELO must be ranked (not practice, private
 											or casual). You can check to see where you're at in your profile page - click on your name in the upper right corner.
 										</p>

--- a/src/frontend-scripts/components/section-main/Players.jsx
+++ b/src/frontend-scripts/components/section-main/Players.jsx
@@ -597,7 +597,7 @@ class Players extends React.Component {
 						this.notRainbowModal = c;
 					}}
 				>
-					<div className="ui header">You do not meet the required amount of XP (50) to play in this game.</div>
+					<div className="ui header">You do not meet the required amount of XP (10) to play in this game.</div>
 				</div>
 
 				<div

--- a/src/frontend-scripts/components/section-right/Playerlist.jsx
+++ b/src/frontend-scripts/components/section-right/Playerlist.jsx
@@ -670,7 +670,7 @@ class Playerlist extends React.Component {
 					<div className="ui basic modal playerlistinfo">
 						<div className="header">Lobby and player color info:</div>
 						<p>
-							Players in the lobby, general chat, and game chat are grey/white until they reach 50 Experience Points (XP). After that, they are known as
+							Players in the lobby, general chat, and game chat are grey/white until they reach 10 Experience Points (XP). After that, they are known as
 							"rainbow players" because their color changes based on their stats. Rainbow players have access to play in special rainbow player only games.
 						</p>
 						<p>

--- a/views/page-howtoplay.pug
+++ b/views/page-howtoplay.pug
@@ -19,7 +19,7 @@ block content
 		p Click on games in the middle to enter them.  You can watch games in progress, enter games that need more players (on top) and take a seat, create your own game, or go to your settings page/look at other player's profiles.
 		image(src="/images/DefaultView.png")
 		h2.ui.centered.header Player settings
-		p You can upload a cardback when you reach "rainbow" status, meaning you've earned 50 XP.
+		p You can upload a cardback when you reach "rainbow" status, meaning you've earned 10 XP.
 		image(src="/images/PlayerSettings.png")
 		h2.ui.centered.header Player profile
 		p Click on a game to see a replay.

--- a/views/page-player-profiles.pug
+++ b/views/page-player-profiles.pug
@@ -50,7 +50,7 @@ block content
 
 			h4.ui.header Ranked Matches
 			p All ranked matches, experienced or otherwise.
-			p #[em Rainbow Matches]: Only Experienced (50+ XP players only) matches.
+			p #[em Rainbow Matches]: Only Experienced (10+ XP players only) matches.
 			p #[em Non-Rainbow Matches]: Only non-Experienced matches.
 
 			h4.ui.header Practice Matches
@@ -61,7 +61,7 @@ block content
 
 			h4.ui.header #[em n] Player Matches
 			p All ranked matches (experienced or otherwise) with #[em n] players.
-			p #[em Rainbow Matches]: Only Experienced (50+ XP players only) matches with #[em n] players.
+			p #[em Rainbow Matches]: Only Experienced (10+ XP players only) matches with #[em n] players.
 			p #[em Non-Rainbow Matches]: Only non-Experienced matches with #[em n] players.
 
 			h3.ui.header Actions


### PR DESCRIPTION
## Changes

Rainbow requirements were for a while at 10 xp. At several places it still said that to get rainbow status you need to get 50 xp or play 50 games. I updated these messages (hopefully) everywhere so it is up to date and new players do not lose motivation thinking they need to play 50 games or gain 50 xp.

## Tested Locally
- [x] This PR makes a trivial change

## Tests
- [x] This PR does not require tests