### PR TITLE
Elo Graph + some Elo metrics!

### DIFF
--- a/models/account.js
+++ b/models/account.js
@@ -225,7 +225,7 @@ const Account = new Schema({
 
 Account.plugin(passportLocalMongoose);
 
-Account.index({ eloOverall: 1 });
-Account.index({ eloSeason: 1 });
+Account.index({ eloOverall: 1, isBanned: 1 });
+Account.index({ eloSeason: 1, isBanned: 1 });
 
 module.exports = mongoose.model('Account', Account);

--- a/models/account.js
+++ b/models/account.js
@@ -225,4 +225,7 @@ const Account = new Schema({
 
 Account.plugin(passportLocalMongoose);
 
+Account.index({ eloOverall: 1 });
+Account.index({ eloSeason: 1 });
+
 module.exports = mongoose.model('Account', Account);

--- a/routes/index.js
+++ b/routes/index.js
@@ -329,51 +329,56 @@ module.exports = () => {
 						Promise.all([
 							getCurrentRankDisplay('eloOverall', Number.isFinite(account.eloOverall) ? account.eloOverall : 1600),
 							getCurrentRankDisplay('eloSeason', Number.isFinite(account.eloSeason) ? account.eloSeason : 1600)
-						]).then(([overallRankDisplay, seasonalRankDisplay]) => {
-							if (overallRankDisplay) _profile.currentOverallRankDisplay = overallRankDisplay;
-							if (seasonalRankDisplay) _profile.currentSeasonalRankDisplay = seasonalRankDisplay;
+						])
+							.then(([overallRankDisplay, seasonalRankDisplay]) => {
+								if (overallRankDisplay) _profile.currentOverallRankDisplay = overallRankDisplay;
+								if (seasonalRankDisplay) _profile.currentSeasonalRankDisplay = seasonalRankDisplay;
 
-							Account.findOne({ username: authedUser }).then(acc => {
-								if (acc && account.username === acc.username) {
-									acc.gameSettings.hasUnseenBadge = false;
-									acc.save();
-								}
-								if (
-									acc &&
-									acc.staffRole &&
-									(acc.staffRole === 'moderator' || acc.staffRole === 'editor' || acc.staffRole === 'admin' || acc.staffRole === 'trialmod')
-								) {
-									try {
-										_profile.lastConnectedIP = '-' + obfIP(account.lastConnectedIP);
-									} catch (e) {
-										_profile.lastConnectedIP = "Couldn't find IP";
-										console.log(e);
+								return Account.findOne({ username: authedUser }).then(acc => {
+									if (acc && account.username === acc.username) {
+										acc.gameSettings.hasUnseenBadge = false;
+										acc.save();
 									}
-									try {
-										_profile.signupIP = '-' + obfIP(account.signupIP);
-									} catch (e) {
-										_profile.signupIP = "Couldn't find IP";
-										console.log(e);
+									if (
+										acc &&
+										acc.staffRole &&
+										(acc.staffRole === 'moderator' || acc.staffRole === 'editor' || acc.staffRole === 'admin' || acc.staffRole === 'trialmod')
+									) {
+										try {
+											_profile.lastConnectedIP = '-' + obfIP(account.lastConnectedIP);
+										} catch (e) {
+											_profile.lastConnectedIP = "Couldn't find IP";
+											console.log(e);
+										}
+										try {
+											_profile.signupIP = '-' + obfIP(account.signupIP);
+										} catch (e) {
+											_profile.signupIP = "Couldn't find IP";
+											console.log(e);
+										}
+										_profile.lastConnected = moment(account.lastConnected).format('MM/DD/YYYY h:mm');
+										_profile.created = moment(account.created).format('MM/DD/YYYY h:mm');
+										if (acc.staffRole !== 'trialmod') {
+											_profile.blacklist = account.gameSettings.blacklist;
+										}
+									} else {
+										_profile.lastConnectedIP = undefined;
+										_profile.signupIP = undefined;
 									}
-									_profile.lastConnected = moment(account.lastConnected).format('MM/DD/YYYY h:mm');
-									_profile.created = moment(account.created).format('MM/DD/YYYY h:mm');
-									if (acc.staffRole !== 'trialmod') {
-										_profile.blacklist = account.gameSettings.blacklist;
-									}
-								} else {
-									_profile.lastConnectedIP = undefined;
-									_profile.signupIP = undefined;
-								}
 
-								if (account.gameSettings.isPrivate && !_profile.lastConnectedIP) {
-									// They are private and lastConnectedIP is set to undefined (ie. requester is not AEM)
-									res.status(404).send('Profile not found');
-									return;
-								}
+									if (account.gameSettings.isPrivate && !_profile.lastConnectedIP) {
+										// They are private and lastConnectedIP is set to undefined (ie. requester is not AEM)
+										res.status(404).send('Profile not found');
+										return;
+									}
 
-								res.json(_profile);
+									res.json(_profile);
+								});
+							})
+							.catch(err => {
+								console.log(err, 'profile load err');
+								res.status(500).send('Error loading profile');
 							});
-						});
 					}
 				});
 			}

--- a/src/frontend-scripts/components/reusable/CollapsibleSegment.jsx
+++ b/src/frontend-scripts/components/reusable/CollapsibleSegment.jsx
@@ -70,7 +70,7 @@ const CollapsibleSegment = props => {
 			</div>
 			<div className="collapsable" {...getCollapseProps()}>
 				<div ref={contentInnerRef} style={{ display: 'flow-root' }}>
-					{props.children}
+					{typeof props.children === 'function' ? props.children({ isExpanded }) : props.children}
 				</div>
 			</div>
 		</div>

--- a/src/frontend-scripts/components/section-main/Profile.jsx
+++ b/src/frontend-scripts/components/section-main/Profile.jsx
@@ -131,13 +131,16 @@ class ProfileWrapper extends React.Component {
 				/>
 				<div className="elo-graph-collapsible">
 					<CollapsibleSegment title={'Elo Graph'}>
-						<ProfileEloGraph
-							key={this.props.profile && this.props.profile._id}
-							profileId={this.props.profile && this.props.profile._id}
-							pastElo={this.props.profile.pastElo}
-							eloOverall={this.props.profile.eloOverall}
-							staffDisableVisibleElo={this.props.profile.staffDisableVisibleElo}
-						/>
+						{({ isExpanded }) => (
+							<ProfileEloGraph
+								key={this.props.profile && this.props.profile._id}
+								profileId={this.props.profile && this.props.profile._id}
+								pastElo={this.props.profile.pastElo}
+								eloOverall={this.props.profile.eloOverall}
+								staffDisableVisibleElo={this.props.profile.staffDisableVisibleElo}
+								isExpanded={isExpanded}
+							/>
+						)}
 					</CollapsibleSegment>
 				</div>
 			</div>

--- a/src/frontend-scripts/components/section-main/Profile.jsx
+++ b/src/frontend-scripts/components/section-main/Profile.jsx
@@ -74,6 +74,17 @@ class ProfileWrapper extends React.Component {
 		const overallRankDisplay = this.props.profile.currentOverallRankDisplay || 'N/A';
 		const seasonalRankDisplay = this.props.profile.currentSeasonalRankDisplay || 'N/A';
 		const peakElo = this.props.profile.maxElo || this.props.profile.eloOverall || 1600;
+		const lifetimeAverageElo = (() => {
+			const pastEloValues = Array.isArray(this.props.profile.pastElo)
+				? this.props.profile.pastElo.map(point => Number(point && point.value)).filter(Number.isFinite)
+				: [];
+
+			if (pastEloValues.length) {
+				return Math.round(pastEloValues.reduce((sum, value) => sum + value, 0) / pastEloValues.length);
+			}
+
+			return Number.isFinite(this.props.profile.eloOverall) ? Math.round(this.props.profile.eloOverall) : 1600;
+		})();
 
 		return (
 			<div>
@@ -103,6 +114,8 @@ class ProfileWrapper extends React.Component {
 											Rank: {overallRankDisplay}
 											<br />
 											Peak: {peakElo}
+											<br />
+											Lifetime Avg: {lifetimeAverageElo}
 										</span>
 									}
 									trigger={<span style={{ cursor: 'help' }}>{this.props.profile.eloOverall || 1600}</span>}

--- a/src/frontend-scripts/components/section-main/Profile.jsx
+++ b/src/frontend-scripts/components/section-main/Profile.jsx
@@ -11,6 +11,7 @@ import { Dropdown, Popup } from 'semantic-ui-react';
 import moment from 'moment';
 import CollapsibleSegment from '../reusable/CollapsibleSegment.jsx';
 import UserPopup from '../reusable/UserPopup.jsx';
+import ProfileEloGraph from './ProfileEloGraph.jsx';
 import { getBlacklistIndex, userInBlacklist } from '../../../../utils';
 import _ from 'lodash';
 
@@ -75,45 +76,58 @@ class ProfileWrapper extends React.Component {
 		const peakElo = this.props.profile.maxElo || this.props.profile.eloOverall || 1600;
 
 		return (
-			<Table
-				headers={['Type', 'Seasonal', 'Overall']}
-				rows={[
-					[
-						'Elo',
-						this.props.profile.staffDisableVisibleElo ? (
-							'---'
-						) : (
-							<Popup
-								inverted
-								position="top center"
-								content={`Rank: ${seasonalRankDisplay}`}
-								trigger={<span style={{ cursor: 'help' }}>{this.props.profile.eloSeason || 1600}</span>}
-							/>
-						),
-						this.props.profile.staffDisableVisibleElo ? (
-							'---'
-						) : (
-							<Popup
-								inverted
-								position="top center"
-								content={
-									<span>
-										Rank: {overallRankDisplay}
-										<br />
-										Peak: {peakElo}
-									</span>
-								}
-								trigger={<span style={{ cursor: 'help' }}>{this.props.profile.eloOverall || 1600}</span>}
-							/>
-						)
-					],
-					[
-						'XP',
-						this.props.profile.staffDisableVisibleXP ? '---' : this.props.profile.xpSeason || 0,
-						this.props.profile.staffDisableVisibleXP ? '---' : this.props.profile.xpOverall || 0
-					]
-				]}
-			/>
+			<div>
+				<Table
+					headers={['Type', 'Seasonal', 'Overall']}
+					rows={[
+						[
+							'Elo',
+							this.props.profile.staffDisableVisibleElo ? (
+								'---'
+							) : (
+								<Popup
+									inverted
+									position="top center"
+									content={`Rank: ${seasonalRankDisplay}`}
+									trigger={<span style={{ cursor: 'help' }}>{this.props.profile.eloSeason || 1600}</span>}
+								/>
+							),
+							this.props.profile.staffDisableVisibleElo ? (
+								'---'
+							) : (
+								<Popup
+									inverted
+									position="top center"
+									content={
+										<span>
+											Rank: {overallRankDisplay}
+											<br />
+											Peak: {peakElo}
+										</span>
+									}
+									trigger={<span style={{ cursor: 'help' }}>{this.props.profile.eloOverall || 1600}</span>}
+								/>
+							)
+						],
+						[
+							'XP',
+							this.props.profile.staffDisableVisibleXP ? '---' : this.props.profile.xpSeason || 0,
+							this.props.profile.staffDisableVisibleXP ? '---' : this.props.profile.xpOverall || 0
+						]
+					]}
+				/>
+				<div className="elo-graph-collapsible">
+					<CollapsibleSegment title={'Elo Graph'}>
+						<ProfileEloGraph
+							key={this.props.profile && this.props.profile._id}
+							profileId={this.props.profile && this.props.profile._id}
+							pastElo={this.props.profile.pastElo}
+							eloOverall={this.props.profile.eloOverall}
+							staffDisableVisibleElo={this.props.profile.staffDisableVisibleElo}
+						/>
+					</CollapsibleSegment>
+				</div>
+			</div>
 		);
 	}
 
@@ -289,12 +303,11 @@ class ProfileWrapper extends React.Component {
 				<br />
 				<br />
 				{badgesToSort.map(x => (
-					<>
+					<React.Fragment key={x.id}>
 						<img
 							style={{ padding: '2px', display: 'inline', cursor: 'pointer' }}
 							src={x.id === 'xp10' ? '../images/rainbowLarge.png' : `../images/badges/${x.id.startsWith('eloReset') ? 'eloReset' : x.id}.png`}
 							alt={x.title}
-							key={x.id}
 							height={50}
 							onClick={() =>
 								Swal.fire({
@@ -310,7 +323,7 @@ class ProfileWrapper extends React.Component {
 								{x.id.substring(8)}
 							</p>
 						) : null}
-					</>
+					</React.Fragment>
 				))}
 			</div>
 		);

--- a/src/frontend-scripts/components/section-main/Profile.jsx
+++ b/src/frontend-scripts/components/section-main/Profile.jsx
@@ -70,14 +70,42 @@ class ProfileWrapper extends React.Component {
 	}
 
 	Elo() {
+		const overallRankDisplay = this.props.profile.currentOverallRankDisplay || 'N/A';
+		const seasonalRankDisplay = this.props.profile.currentSeasonalRankDisplay || 'N/A';
+		const peakElo = this.props.profile.maxElo || this.props.profile.eloOverall || 1600;
+
 		return (
 			<Table
 				headers={['Type', 'Seasonal', 'Overall']}
 				rows={[
 					[
 						'Elo',
-						this.props.profile.staffDisableVisibleElo ? '---' : this.props.profile.eloSeason || 1600,
-						this.props.profile.staffDisableVisibleElo ? '---' : this.props.profile.eloOverall || 1600
+						this.props.profile.staffDisableVisibleElo ? (
+							'---'
+						) : (
+							<Popup
+								inverted
+								position="top center"
+								content={`Rank: ${seasonalRankDisplay}`}
+								trigger={<span style={{ cursor: 'help' }}>{this.props.profile.eloSeason || 1600}</span>}
+							/>
+						),
+						this.props.profile.staffDisableVisibleElo ? (
+							'---'
+						) : (
+							<Popup
+								inverted
+								position="top center"
+								content={
+									<span>
+										Rank: {overallRankDisplay}
+										<br />
+										Peak: {peakElo}
+									</span>
+								}
+								trigger={<span style={{ cursor: 'help' }}>{this.props.profile.eloOverall || 1600}</span>}
+							/>
+						)
 					],
 					[
 						'XP',

--- a/src/frontend-scripts/components/section-main/ProfileEloGraph.jsx
+++ b/src/frontend-scripts/components/section-main/ProfileEloGraph.jsx
@@ -110,52 +110,22 @@ class ProfileEloGraph extends React.Component {
 		this.eloGraphMemo = null;
 		this.eloGraphHoverRaf = null;
 		this.pendingEloGraphHoverIndex = null;
-		this.graphRootRef = React.createRef();
-		this.graphContainerResizeObserver = null;
-		this.isGraphContainerOpen = false;
 	}
 
-	componentDidMount() {
-		this.bindGraphContainerObserver();
+	componentDidUpdate(prevProps) {
+		if (this.props.isExpanded && !prevProps.isExpanded) {
+			this.setState(prev => ({
+				lineAnimationSeed: prev.lineAnimationSeed + 1,
+				lineAnimationDelayMs: 400
+			}));
+		}
 	}
 
 	componentWillUnmount() {
 		if (this.eloGraphHoverRaf && typeof window !== 'undefined' && window.cancelAnimationFrame) {
 			window.cancelAnimationFrame(this.eloGraphHoverRaf);
 		}
-		if (this.graphContainerResizeObserver) {
-			this.graphContainerResizeObserver.disconnect();
-		}
 	}
-
-	bindGraphContainerObserver = () => {
-		if (typeof ResizeObserver === 'undefined' || !this.graphRootRef.current) {
-			return;
-		}
-
-		const collapsable = this.graphRootRef.current.closest('.collapsable');
-		if (!collapsable) {
-			return;
-		}
-
-		const syncContainerOpenState = () => {
-			const isOpen = collapsable.getBoundingClientRect().height > 1;
-			if (isOpen && !this.isGraphContainerOpen) {
-				this.setState(prev => ({
-					lineAnimationSeed: prev.lineAnimationSeed + 1,
-					lineAnimationDelayMs: 400
-				}));
-			}
-			this.isGraphContainerOpen = isOpen;
-		};
-
-		syncContainerOpenState();
-
-		this.graphContainerResizeObserver = new ResizeObserver(() => {
-			syncContainerOpenState();
-		});
-		this.graphContainerResizeObserver.observe(collapsable);
-	};
 
 	scheduleEloGraphHoverUpdate = nextIndex => {
 		this.pendingEloGraphHoverIndex = nextIndex;
@@ -297,7 +267,7 @@ class ProfileEloGraph extends React.Component {
 		const polylineAnimationKey = `${this.state.eloGraphRange}-${this.state.lineAnimationSeed}`;
 
 		return (
-			<div className="elo-graph" ref={this.graphRootRef}>
+			<div className="elo-graph">
 				<div className="elo-graph-controls">
 					{ELO_GRAPH_RANGES.map(range => (
 						<button
@@ -385,14 +355,16 @@ ProfileEloGraph.defaultProps = {
 	profileId: undefined,
 	pastElo: undefined,
 	eloOverall: undefined,
-	staffDisableVisibleElo: false
+	staffDisableVisibleElo: false,
+	isExpanded: false
 };
 
 ProfileEloGraph.propTypes = {
 	profileId: PropTypes.string,
 	pastElo: PropTypes.array,
 	eloOverall: PropTypes.number,
-	staffDisableVisibleElo: PropTypes.bool
+	staffDisableVisibleElo: PropTypes.bool,
+	isExpanded: PropTypes.bool
 };
 
 export default ProfileEloGraph;

--- a/src/frontend-scripts/components/section-main/ProfileEloGraph.jsx
+++ b/src/frontend-scripts/components/section-main/ProfileEloGraph.jsx
@@ -1,0 +1,398 @@
+import React from 'react'; // eslint-disable-line no-unused-vars
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import { getEloBucketIndex } from '../../constants';
+
+const ELO_GRAPH_RANGES = [
+	{ key: '1W', label: '1W', days: 7 },
+	{ key: '1M', label: '1M', days: 30 },
+	{ key: '3M', label: '3M', days: 90 },
+	{ key: '1Y', label: '1Y', days: 365 },
+	{ key: 'ALL', label: 'All', days: null }
+];
+
+const EMPTY_PAST_ELO = [];
+
+const getNearestPointIndexByX = (plottedPoints, mouseX) => {
+	if (!plottedPoints.length) {
+		return null;
+	}
+
+	let low = 0;
+	let high = plottedPoints.length - 1;
+
+	while (low < high) {
+		const mid = Math.floor((low + high) / 2);
+		if (plottedPoints[mid].x < mouseX) {
+			low = mid + 1;
+		} else {
+			high = mid;
+		}
+	}
+
+	const right = low;
+	if (right === 0) {
+		return 0;
+	}
+
+	const left = right - 1;
+	return Math.abs(plottedPoints[right].x - mouseX) < Math.abs(plottedPoints[left].x - mouseX) ? right : left;
+};
+
+const downsamplePointsForGraph = (points, maxPoints) => {
+	if (points.length <= maxPoints) {
+		return points;
+	}
+
+	const sampled = [];
+	const seen = new Set();
+	const pushUnique = point => {
+		const key = `${point.date.getTime()}|${point.value}`;
+		if (!seen.has(key)) {
+			seen.add(key);
+			sampled.push(point);
+		}
+	};
+
+	pushUnique(points[0]);
+
+	const interior = points.slice(1, -1);
+	if (interior.length) {
+		const bucketCount = Math.max(1, Math.floor((maxPoints - 2) / 4));
+		const bucketSize = Math.ceil(interior.length / bucketCount);
+
+		for (let start = 0; start < interior.length; start += bucketSize) {
+			const bucket = interior.slice(start, start + bucketSize);
+			if (!bucket.length) {
+				continue;
+			}
+
+			let minPoint = bucket[0];
+			let maxPoint = bucket[0];
+			for (let i = 1; i < bucket.length; i++) {
+				if (bucket[i].value < minPoint.value) {
+					minPoint = bucket[i];
+				}
+				if (bucket[i].value > maxPoint.value) {
+					maxPoint = bucket[i];
+				}
+			}
+
+			[bucket[0], minPoint, maxPoint, bucket[bucket.length - 1]].sort((a, b) => a.date - b.date).forEach(pushUnique);
+		}
+	}
+
+	pushUnique(points[points.length - 1]);
+	return sampled.sort((a, b) => a.date - b.date);
+};
+
+const getPolylineLength = plottedPoints => {
+	if (plottedPoints.length < 2) {
+		return 1;
+	}
+
+	let total = 0;
+	for (let i = 1; i < plottedPoints.length; i++) {
+		total += Math.hypot(plottedPoints[i].x - plottedPoints[i - 1].x, plottedPoints[i].y - plottedPoints[i - 1].y);
+	}
+	return Math.max(total, 1);
+};
+
+class ProfileEloGraph extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			eloGraphRange: '1M',
+			eloGraphHoverIndex: null,
+			lineAnimationSeed: 0,
+			lineAnimationDelayMs: 0
+		};
+		this.eloGraphMemo = null;
+		this.eloGraphHoverRaf = null;
+		this.pendingEloGraphHoverIndex = null;
+		this.graphRootRef = React.createRef();
+		this.graphContainerResizeObserver = null;
+		this.isGraphContainerOpen = false;
+	}
+
+	componentDidMount() {
+		this.bindGraphContainerObserver();
+	}
+
+	componentWillUnmount() {
+		if (this.eloGraphHoverRaf && typeof window !== 'undefined' && window.cancelAnimationFrame) {
+			window.cancelAnimationFrame(this.eloGraphHoverRaf);
+		}
+		if (this.graphContainerResizeObserver) {
+			this.graphContainerResizeObserver.disconnect();
+		}
+	}
+
+	bindGraphContainerObserver = () => {
+		if (typeof ResizeObserver === 'undefined' || !this.graphRootRef.current) {
+			return;
+		}
+
+		const collapsable = this.graphRootRef.current.closest('.collapsable');
+		if (!collapsable) {
+			return;
+		}
+
+		const syncContainerOpenState = () => {
+			const isOpen = collapsable.getBoundingClientRect().height > 1;
+			if (isOpen && !this.isGraphContainerOpen) {
+				this.setState(prev => ({
+					lineAnimationSeed: prev.lineAnimationSeed + 1,
+					lineAnimationDelayMs: 400
+				}));
+			}
+			this.isGraphContainerOpen = isOpen;
+		};
+
+		syncContainerOpenState();
+
+		this.graphContainerResizeObserver = new ResizeObserver(() => {
+			syncContainerOpenState();
+		});
+		this.graphContainerResizeObserver.observe(collapsable);
+	};
+
+	scheduleEloGraphHoverUpdate = nextIndex => {
+		this.pendingEloGraphHoverIndex = nextIndex;
+
+		if (this.eloGraphHoverRaf) {
+			return;
+		}
+
+		const flush = () => {
+			this.eloGraphHoverRaf = null;
+			const pending = this.pendingEloGraphHoverIndex;
+			this.pendingEloGraphHoverIndex = null;
+
+			if (pending !== this.state.eloGraphHoverIndex) {
+				this.setState({ eloGraphHoverIndex: pending });
+			}
+		};
+
+		if (typeof window !== 'undefined' && window.requestAnimationFrame) {
+			this.eloGraphHoverRaf = window.requestAnimationFrame(flush);
+		} else {
+			flush();
+		}
+	};
+
+	resetEloGraphHover = () => {
+		if (this.eloGraphHoverRaf && typeof window !== 'undefined' && window.cancelAnimationFrame) {
+			window.cancelAnimationFrame(this.eloGraphHoverRaf);
+			this.eloGraphHoverRaf = null;
+		}
+		this.pendingEloGraphHoverIndex = null;
+
+		if (this.state.eloGraphHoverIndex !== null) {
+			this.setState({ eloGraphHoverIndex: null });
+		}
+	};
+
+	getEloGraphData() {
+		const { profileId, pastElo, eloOverall } = this.props;
+		const rawPastElo = Array.isArray(pastElo) ? pastElo : EMPTY_PAST_ELO;
+		const fallbackOverallElo = Number.isFinite(eloOverall) ? Number(eloOverall) : null;
+		const rangeKey = this.state.eloGraphRange;
+
+		if (
+			this.eloGraphMemo &&
+			this.eloGraphMemo.profileId === profileId &&
+			this.eloGraphMemo.rawPastElo === rawPastElo &&
+			this.eloGraphMemo.fallbackOverallElo === fallbackOverallElo &&
+			this.eloGraphMemo.rangeKey === rangeKey
+		) {
+			return this.eloGraphMemo.data;
+		}
+
+		let points = rawPastElo
+			.map(point => {
+				const date = new Date(point.date);
+				const value = Number(point.value);
+				if (!Number.isFinite(value) || Number.isNaN(date.getTime())) {
+					return null;
+				}
+				return { date, value };
+			})
+			.filter(Boolean)
+			.sort((a, b) => a.date - b.date);
+
+		if (!points.length && Number.isFinite(fallbackOverallElo)) {
+			points = [{ date: new Date(), value: fallbackOverallElo }];
+		}
+
+		const selectedRange = ELO_GRAPH_RANGES.find(range => range.key === rangeKey) || ELO_GRAPH_RANGES[1];
+		if (selectedRange.days) {
+			const cutoff = Date.now() - selectedRange.days * 24 * 60 * 60 * 1000;
+			const filtered = points.filter(point => point.date.getTime() >= cutoff);
+			points = filtered.length ? filtered : points.length ? [points[points.length - 1]] : [];
+		}
+
+		const width = 680;
+		const height = 240;
+		const margin = { top: 4, right: 4, bottom: 4, left: 4 };
+		const graphWidth = width - margin.left - margin.right;
+		const graphHeight = height - margin.top - margin.bottom;
+		const maxRenderPoints = Math.max(50, Math.floor(graphWidth));
+		points = downsamplePointsForGraph(points, maxRenderPoints);
+
+		let plottedPoints = [];
+		let polylinePoints = '';
+
+		if (points.length) {
+			const minTime = points[0].date.getTime();
+			const maxTime = points[points.length - 1].date.getTime();
+			const timeSpan = Math.max(maxTime - minTime, 1);
+
+			let minElo = Math.min(...points.map(point => point.value));
+			let maxElo = Math.max(...points.map(point => point.value));
+			if (minElo === maxElo) {
+				minElo -= 10;
+				maxElo += 10;
+			}
+
+			const xAt = point => {
+				if (points.length === 1) {
+					return margin.left + graphWidth / 2;
+				}
+				return margin.left + ((point.date.getTime() - minTime) / timeSpan) * graphWidth;
+			};
+			const yAt = point => margin.top + ((maxElo - point.value) / (maxElo - minElo)) * graphHeight;
+
+			plottedPoints = points.map(point => ({
+				point,
+				x: xAt(point),
+				y: yAt(point)
+			}));
+			polylinePoints = plottedPoints.map(plotted => `${plotted.x},${plotted.y}`).join(' ');
+		}
+
+		const data = { points, width, height, margin, graphHeight, plottedPoints, polylinePoints };
+		this.eloGraphMemo = { profileId, rawPastElo, fallbackOverallElo, rangeKey, data };
+		return data;
+	}
+
+	render() {
+		if (this.props.staffDisableVisibleElo) {
+			return <div className="elo-graph-empty">---</div>;
+		}
+
+		const { points, width, height, margin, graphHeight, plottedPoints, polylinePoints } = this.getEloGraphData();
+		if (!points.length) {
+			return <div className="elo-graph-empty">No Elo history yet.</div>;
+		}
+
+		const hoverIndex = this.state.eloGraphHoverIndex;
+		const hoverPoint = Number.isInteger(hoverIndex) ? points[hoverIndex] : null;
+		const infoPoint = hoverPoint || points[points.length - 1];
+		const hoveredPlottedPoint = Number.isInteger(hoverIndex) ? plottedPoints[hoverIndex] : null;
+		const lineColor = 'var(--theme-secondary)';
+		const infoColor = `var(--elo-color-${getEloBucketIndex(infoPoint.value)})`;
+		const markerColor = hoveredPlottedPoint ? `var(--elo-color-${getEloBucketIndex(hoveredPlottedPoint.point.value)})` : lineColor;
+		const polylineLength = getPolylineLength(plottedPoints);
+		const polylineAnimationKey = `${this.state.eloGraphRange}-${this.state.lineAnimationSeed}`;
+
+		return (
+			<div className="elo-graph" ref={this.graphRootRef}>
+				<div className="elo-graph-controls">
+					{ELO_GRAPH_RANGES.map(range => (
+						<button
+							type="button"
+							key={range.key}
+							className={`ui mini button ${this.state.eloGraphRange === range.key ? 'primary' : ''}`}
+							onClick={() => {
+								this.eloGraphMemo = null;
+								this.resetEloGraphHover();
+								this.setState(prev => ({
+									eloGraphRange: range.key,
+									lineAnimationSeed: prev.lineAnimationSeed + 1,
+									lineAnimationDelayMs: 0
+								}));
+							}}
+						>
+							{range.label}
+						</button>
+					))}
+				</div>
+				<div className="elo-graph-summary">
+					<span className="elo-graph-summary-title">{hoverPoint ? 'Selected' : 'Latest'}:</span>{' '}
+					<span style={{ color: infoColor }}>
+						{Math.round(infoPoint.value)} ({moment(infoPoint.date).format('MM/DD/YYYY HH:mm')})
+					</span>
+				</div>
+				<div className="elo-graph-canvas">
+					<svg
+						className="elo-graph-svg"
+						viewBox={`0 0 ${width} ${height}`}
+						role="img"
+						aria-label="Elo history graph"
+						onMouseMove={event => {
+							const rect = event.currentTarget.getBoundingClientRect();
+							if (!rect.width) {
+								return;
+							}
+
+							const mouseX = ((event.clientX - rect.left) / rect.width) * width;
+							const nextIndex = getNearestPointIndexByX(plottedPoints, mouseX);
+							if (nextIndex !== null) {
+								this.scheduleEloGraphHoverUpdate(nextIndex);
+							}
+						}}
+						onMouseLeave={this.resetEloGraphHover}
+					>
+						<polyline
+							key={polylineAnimationKey}
+							className="elo-graph-line-draw"
+							fill="none"
+							stroke={lineColor}
+							strokeWidth="3"
+							points={polylinePoints}
+							style={{
+								'--elo-graph-path-length': `${polylineLength}`,
+								'--elo-graph-line-delay': `${this.state.lineAnimationDelayMs}ms`
+							}}
+						/>
+						{hoveredPlottedPoint && (
+							<>
+								<line
+									x1={hoveredPlottedPoint.x}
+									y1={margin.top}
+									x2={hoveredPlottedPoint.x}
+									y2={margin.top + graphHeight}
+									stroke={markerColor}
+									strokeWidth="3"
+									opacity="0.75"
+								/>
+								<circle cx={hoveredPlottedPoint.x} cy={hoveredPlottedPoint.y} r={8} fill={markerColor} stroke="var(--theme-background-1)" strokeWidth="1">
+									<title>
+										{Math.round(hoveredPlottedPoint.point.value)} ({moment(hoveredPlottedPoint.point.date).format('MM/DD/YYYY HH:mm')})
+									</title>
+								</circle>
+							</>
+						)}
+					</svg>
+				</div>
+			</div>
+		);
+	}
+}
+
+ProfileEloGraph.defaultProps = {
+	profileId: undefined,
+	pastElo: undefined,
+	eloOverall: undefined,
+	staffDisableVisibleElo: false
+};
+
+ProfileEloGraph.propTypes = {
+	profileId: PropTypes.string,
+	pastElo: PropTypes.array,
+	eloOverall: PropTypes.number,
+	staffDisableVisibleElo: PropTypes.bool
+};
+
+export default ProfileEloGraph;

--- a/src/frontend-scripts/components/section-main/profileelograph.test.js
+++ b/src/frontend-scripts/components/section-main/profileelograph.test.js
@@ -1,0 +1,76 @@
+import React from 'react'; // eslint-disable-line
+import { shallow } from 'enzyme';
+import ProfileEloGraph from './ProfileEloGraph';
+
+describe('ProfileEloGraph', () => {
+	it('renders hidden state when visible elo is disabled', () => {
+		const component = shallow(<ProfileEloGraph staffDisableVisibleElo={true} />);
+
+		expect(component.find('.elo-graph-empty')).toHaveLength(1);
+		expect(component.text()).toContain('---');
+	});
+
+	it('renders graph shell when valid pastElo exists', () => {
+		const component = shallow(
+			<ProfileEloGraph
+				profileId="Rexxar"
+				pastElo={[
+					{ date: '2026-02-10T01:00:00.000Z', value: 1600 },
+					{ date: '2026-02-11T01:00:00.000Z', value: 1615 },
+					{ date: '2026-02-12T01:00:00.000Z', value: 1598 }
+				]}
+			/>
+		);
+
+		expect(component.find('.elo-graph-controls button')).toHaveLength(5);
+		expect(component.find('svg.elo-graph-svg')).toHaveLength(1);
+	});
+
+	it('falls back safely when pastElo is empty and eloOverall exists', () => {
+		const component = shallow(<ProfileEloGraph profileId="Rexxar" pastElo={[]} eloOverall={1700} />);
+
+		expect(component.find('svg.elo-graph-svg')).toHaveLength(1);
+		expect(component.find('.elo-graph-summary-title').text()).toBe('Latest:');
+		expect(
+			component
+				.find('.elo-graph-summary span')
+				.at(1)
+				.prop('style')
+		).toEqual({ color: 'var(--elo-color-40)' });
+	});
+
+	it('does not crash with malformed points', () => {
+		const component = shallow(
+			<ProfileEloGraph
+				profileId="Rexxar"
+				pastElo={[
+					{ date: 'not-a-date', value: 1600 },
+					{ date: '2026-02-12T01:00:00.000Z', value: 'not-a-number' }
+				]}
+			/>
+		);
+
+		expect(component.find('.elo-graph-empty')).toHaveLength(1);
+		expect(component.text()).toContain('No Elo history yet.');
+	});
+
+	it('uses bucket css vars for selected marker color', () => {
+		const component = shallow(
+			<ProfileEloGraph
+				profileId="Rexxar"
+				pastElo={[
+					{ date: '2026-02-10T01:00:00.000Z', value: 1600 },
+					{ date: '2026-02-11T01:00:00.000Z', value: 1615 }
+				]}
+			/>
+		);
+
+		component.setState({ eloGraphHoverIndex: 1 });
+		expect(
+			component
+				.find('line')
+				.first()
+				.prop('stroke')
+		).toBe('var(--elo-color-23)');
+	});
+});

--- a/src/frontend-scripts/constants.js
+++ b/src/frontend-scripts/constants.js
@@ -50,6 +50,12 @@ export const LEGALCHARACTERS = text => {
 	return pass;
 };
 
+export const getEloBucketIndex = elo => {
+	const parsed = elo === null || elo === undefined ? NaN : Number(elo);
+	const boundedElo = Number.isFinite(parsed) ? Math.min(2100, Math.max(1500, parsed)) : 1600;
+	return Math.round((boundedElo - 1500) / 5);
+};
+
 /**
  * @param {object} user - user from userlist.
  * @param {boolean} isSeasonal - whether or not to display seasonal colors.
@@ -80,16 +86,8 @@ export const PLAYERCOLORS = (user, isSeasonal, defaultClass, eloDisabled) => {
 		const l = isSeasonal ? user.lossesSeason : user.losses;
 		const rainbow = isSeasonal ? user.isRainbowSeason : user.isRainbowOverall;
 		const elo = isSeasonal ? user.eloSeason : user.eloOverall;
-		let grade;
-		if (elo < 1500) {
-			grade = 0;
-		} else if (elo > 2100) {
-			grade = 600 / 5;
-		} else {
-			grade = (elo - 1500) / 5;
-		}
 		const gradeObj = {};
-		gradeObj['elo' + grade.toFixed(0)] = true;
+		gradeObj[`elo${getEloBucketIndex(elo)}`] = true;
 
 		return rainbow
 			? eloDisabled

--- a/src/frontend-scripts/constants.test.js
+++ b/src/frontend-scripts/constants.test.js
@@ -1,0 +1,18 @@
+import { getEloBucketIndex } from './constants';
+
+describe('getEloBucketIndex', () => {
+	it('clamps and rounds to the expected bucket index', () => {
+		expect(getEloBucketIndex(1499)).toBe(0);
+		expect(getEloBucketIndex(1500)).toBe(0);
+		expect(getEloBucketIndex(1502)).toBe(0);
+		expect(getEloBucketIndex(1503)).toBe(1);
+		expect(getEloBucketIndex(2100)).toBe(120);
+		expect(getEloBucketIndex(2200)).toBe(120);
+	});
+
+	it('falls back to 1600 bucket on invalid input', () => {
+		expect(getEloBucketIndex(undefined)).toBe(20);
+		expect(getEloBucketIndex(null)).toBe(20);
+		expect(getEloBucketIndex('bad')).toBe(20);
+	});
+});

--- a/src/frontend-scripts/node-constants.js
+++ b/src/frontend-scripts/node-constants.js
@@ -50,6 +50,12 @@ module.exports.LEGALCHARACTERS = text => {
 	return pass;
 };
 
+module.exports.getEloBucketIndex = elo => {
+	const parsed = elo === null || elo === undefined ? NaN : Number(elo);
+	const boundedElo = Number.isFinite(parsed) ? Math.min(2100, Math.max(1500, parsed)) : 1600;
+	return Math.round((boundedElo - 1500) / 5);
+};
+
 /**
  * @param {object} user - user from userlist.
  * @param {boolean} isSeasonal - whether or not to display seasonal colors.
@@ -80,16 +86,8 @@ module.exports.PLAYERCOLORS = (user, isSeasonal, defaultClass, eloDisabled) => {
 		const l = isSeasonal ? user.lossesSeason : user.losses;
 		const rainbow = isSeasonal ? user.isRainbowSeason : user.isRainbowOverall;
 		const elo = isSeasonal ? user.eloSeason : user.eloOverall;
-		let grade;
-		if (elo < 1500) {
-			grade = 0;
-		} else if (elo > 2100) {
-			grade = 600 / 5;
-		} else {
-			grade = (elo - 1500) / 5;
-		}
 		const gradeObj = {};
-		gradeObj['elo' + grade.toFixed(0)] = true;
+		gradeObj[`elo${module.exports.getEloBucketIndex(elo)}`] = true;
 
 		return rainbow
 			? eloDisabled

--- a/src/scss/elo-colors-core.scss
+++ b/src/scss/elo-colors-core.scss
@@ -1,0 +1,46 @@
+$eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (1900 0.9 1 0.6) (2000 0.8 1 0.4) (2100 0.7 1 0.5);
+
+@function eloColorLerp($low, $high, $elo) {
+	$scale: nth($high, 1) - nth($low, 1);
+	@if $scale <= 0 {
+		@return hsl(nth($low, 2) * 360, nth($low, 3) * 100, nth($low, 4) * 100);
+	}
+	$lerp: ($elo - nth($low, 1)) / $scale;
+	@if $lerp < 0 {
+		$lerp: 0;
+	}
+	@if $lerp > 1 {
+		$lerp: 1;
+	}
+	@return hsl(
+		((nth($low, 2) * (1-$lerp)) + (nth($high, 2) * $lerp)) * 360,
+		((nth($low, 3) * (1-$lerp)) + (nth($high, 3) * $lerp)) * 100,
+		((nth($low, 4) * (1-$lerp)) + (nth($high, 4) * $lerp)) * 100
+	);
+}
+
+@function calcEloCol($elo) {
+	$low: nth($eloValues, 1);
+	$high: nth($eloValues, -1);
+	@for $i from 1 through length($eloValues) {
+		$val: nth($eloValues, $i);
+		$val2: nth($val, 1);
+		@if $val2 > nth($low, 1) {
+			@if $val2 <= $elo {
+				$low: $val;
+			}
+		}
+		@if $val2 < nth($high, 1) {
+			@if $val2 >= $elo {
+				$high: $val;
+			}
+		}
+	}
+	@return eloColorLerp($low, $high, $elo);
+}
+
+@mixin emit-elo-color-vars() {
+	@for $i from 0 through 120 {
+		--elo-color-#{$i}: #{calcEloCol($i * 5 + 1500)};
+	}
+}

--- a/src/scss/players.scss
+++ b/src/scss/players.scss
@@ -1,43 +1,4 @@
-$eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (1900 0.9 1 0.6) (2000 0.8 1 0.4) (2100 0.7 1 0.5);
-
-@function lerp($low, $high, $elo) {
-	$scale: nth($high, 1) - nth($low, 1);
-	@if $scale <= 0 {
-		@return hsl(nth($low, 2) * 360, nth($low, 3) * 100, nth($low, 4) * 100);
-	}
-	$lerp: ($elo - nth($low, 1)) / $scale;
-	@if $lerp < 0 {
-		$lerp: 0;
-	}
-	@if $lerp > 1 {
-		$lerp: 1;
-	}
-	@return hsl(
-		((nth($low, 2) * (1-$lerp)) + (nth($high, 2) * $lerp)) * 360,
-		((nth($low, 3) * (1-$lerp)) + (nth($high, 3) * $lerp)) * 100,
-		((nth($low, 4) * (1-$lerp)) + (nth($high, 4) * $lerp)) * 100
-	);
-}
-
-@function calcEloCol($elo) {
-	$low: nth($eloValues, 1);
-	$high: nth($eloValues, -1);
-	@for $i from 1 through length($eloValues) {
-		$val: nth($eloValues, $i);
-		$val2: nth($val, 1);
-		@if $val2 > nth($low, 1) {
-			@if $val2 <= $elo {
-				$low: $val;
-			}
-		}
-		@if $val2 < nth($high, 1) {
-			@if $val2 >= $elo {
-				$high: $val;
-			}
-		}
-	}
-	@return lerp($low, $high, $elo);
-}
+@import 'elo-colors-core';
 
 .players-container {
 	border-top: 1px solid var(--theme-background-3);

--- a/src/scss/profile.scss
+++ b/src/scss/profile.scss
@@ -1,43 +1,4 @@
-$eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (1900 0.9 1 0.6) (2000 0.8 1 0.4) (2100 0.7 1 0.5);
-
-@function lerp($low, $high, $elo) {
-	$scale: nth($high, 1) - nth($low, 1);
-	@if $scale <= 0 {
-		@return hsl(nth($low, 2) * 360, nth($low, 3) * 100, nth($low, 4) * 100);
-	}
-	$lerp: ($elo - nth($low, 1)) / $scale;
-	@if $lerp < 0 {
-		$lerp: 0;
-	}
-	@if $lerp > 1 {
-		$lerp: 1;
-	}
-	@return hsl(
-		((nth($low, 2) * (1-$lerp)) + (nth($high, 2) * $lerp)) * 360,
-		((nth($low, 3) * (1-$lerp)) + (nth($high, 3) * $lerp)) * 100,
-		((nth($low, 4) * (1-$lerp)) + (nth($high, 4) * $lerp)) * 100
-	);
-}
-
-@function calcEloCol($elo) {
-	$low: nth($eloValues, 1);
-	$high: nth($eloValues, -1);
-	@for $i from 1 through length($eloValues) {
-		$val: nth($eloValues, $i);
-		$val2: nth($val, 1);
-		@if $val2 > nth($low, 1) {
-			@if $val2 <= $elo {
-				$low: $val;
-			}
-		}
-		@if $val2 < nth($high, 1) {
-			@if $val2 >= $elo {
-				$high: $val;
-			}
-		}
-	}
-	@return lerp($low, $high, $elo);
-}
+@import 'elo-colors-core';
 
 #profile {
 	border: 0;
@@ -154,6 +115,61 @@ $eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (190
 
 	.bio + p {
 		margin-bottom: 10px;
+	}
+
+	.elo-graph-controls {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+		margin-bottom: 8px;
+	}
+
+	.elo-graph-summary,
+	.elo-graph-empty {
+		font-size: 14px;
+		margin-bottom: 8px;
+		min-height: 18px;
+	}
+
+	.elo-graph-summary-title {
+		font-weight: 700;
+	}
+
+	.elo-graph-canvas {
+		background: var(--theme-background-3);
+		border: 1px solid var(--theme-secondary);
+		border-radius: 4px;
+		padding: 6px;
+	}
+
+	.elo-graph-svg {
+		width: 100%;
+		height: auto;
+		aspect-ratio: 680 / 240;
+		display: block;
+		cursor: crosshair;
+	}
+
+	.elo-graph-line-draw {
+		stroke-dasharray: var(--elo-graph-path-length);
+		stroke-dashoffset: var(--elo-graph-path-length);
+		animation: profile-elo-graph-draw 550ms ease-out var(--elo-graph-line-delay, 0ms) forwards;
+	}
+
+	.elo-graph-collapsible {
+		.collapsable {
+			padding-bottom: 0;
+		}
+
+		.column-name + .collapsable {
+			margin-bottom: 0.5rem;
+		}
+	}
+
+	@keyframes profile-elo-graph-draw {
+		to {
+			stroke-dashoffset: 0;
+		}
 	}
 }
 

--- a/src/scss/style-dark.scss
+++ b/src/scss/style-dark.scss
@@ -12,6 +12,7 @@
 @import 'moderation.scss';
 @import 'game-text.scss';
 @import 'reports.scss';
+@import 'elo-colors-core';
 
 .thumb-vertical {
 	cursor: pointer;
@@ -972,45 +973,8 @@ div {
 	margin-left: -237px;
 }
 
-$eloValues: (1500 0.3 1 0.3) (1600 0.3 1 0.5) (1849 0 1 0.7) (1850 1 1 0.7) (1900 0.9 1 0.6) (2000 0.8 1 0.4) (2100 0.7 1 0.5);
-
-@function lerp($low, $high, $elo) {
-	$scale: nth($high, 1) - nth($low, 1);
-	@if $scale <= 0 {
-		@return hsl(nth($low, 2) * 360, nth($low, 3) * 100, nth($low, 4) * 100);
-	}
-	$lerp: ($elo - nth($low, 1)) / $scale;
-	@if $lerp < 0 {
-		$lerp: 0;
-	}
-	@if $lerp > 1 {
-		$lerp: 1;
-	}
-	@return hsl(
-		((nth($low, 2) * (1-$lerp)) + (nth($high, 2) * $lerp)) * 360,
-		((nth($low, 3) * (1-$lerp)) + (nth($high, 3) * $lerp)) * 100,
-		((nth($low, 4) * (1-$lerp)) + (nth($high, 4) * $lerp)) * 100
-	);
-}
-
-@function calcEloCol($elo) {
-	$low: nth($eloValues, 1);
-	$high: nth($eloValues, -1);
-	@for $i from 1 through length($eloValues) {
-		$val: nth($eloValues, $i);
-		$val2: nth($val, 1);
-		@if $val2 > nth($low, 1) {
-			@if $val2 <= $elo {
-				$low: $val;
-			}
-		}
-		@if $val2 < nth($high, 1) {
-			@if $val2 >= $elo {
-				$high: $val;
-			}
-		}
-	}
-	@return lerp($low, $high, $elo);
+:root {
+	@include emit-elo-color-vars();
 }
 
 @for $i from 0 through 120 {


### PR DESCRIPTION
## Changes

New Elo-related features:
- Add an interactive line chart to the profile that visualizes a player's Elo over time
- Display current season rank, overall rank, peak overall, and lifetime average Elo on hover in the profile's Elo section
- Small refactor of a part of the colour system (extract shared Elo colour logic into a reusable elo-colors-core.scss)

## Screenshots
<img width="422" height="173" alt="Screenshot 2026-02-19 at 7 44 49 PM" src="https://github.com/user-attachments/assets/552e8eca-f08a-4110-ad45-14d7de287d03" />
<img width="421" height="173" alt="Screenshot 2026-02-19 at 7 44 40 PM" src="https://github.com/user-attachments/assets/7afb4243-d9ad-4345-b260-41579f02f783" />
<img width="416" height="771" alt="Screenshot 2026-02-19 at 7 44 01 PM" src="https://github.com/user-attachments/assets/dfa16f10-2e49-4541-bab9-4c6cb1bc6da0" />
<img width="430" height="813" alt="Screenshot 2026-02-19 at 7 43 46 PM" src="https://github.com/user-attachments/assets/2d59f240-0448-47ce-84e0-84ff0a9c4756" />

---

## Tested Locally
- [x] This PR has been tested locally, and ensured to not cause any breaking changes

## Tests
- [x] Automated tests have been added

## Changelog
- [x] Changelog Section below has been updated with Changelog entry

### Changelog Entry (delete this section if this PR does not need a changelog entry)

Check one, delete the other:
- [x] New Feature

Check one, delete the other:
- [x] Minor Change

**Changelog Headline**: Profile Elo enhancements and Elo graph

**Changelog Details**: Added an Elo history graph, rank tooltips (season rank, overall rank, peak Elo), and lifetime average Elo to the player profile page.