### PR TITLE
feat: add slow chat mode game setting

### DIFF
--- a/models/game.js
+++ b/models/game.js
@@ -42,6 +42,7 @@ const Game = new Schema({
 		withPercival: Boolean
 	},
 	noTopdecking: Number,
+	slowChatMode: Number,
 	completed: Boolean
 });
 

--- a/routes/socket/models.js
+++ b/routes/socket/models.js
@@ -273,7 +273,8 @@ module.exports.formattedGameList = () => {
 		isUnlisted: games[gameName].general.unlistedGame || undefined,
 		avalonSH: games[gameName].general.avalonSH || undefined,
 		monarchistSH: games[gameName].general.monarchistSH || undefined,
-		noTopdecking: games[gameName].general.noTopdecking || undefined
+		noTopdecking: games[gameName].general.noTopdecking || undefined,
+		slowChatMode: games[gameName].general.slowChatMode || undefined
 	}));
 };
 

--- a/routes/socket/user-events/chat.js
+++ b/routes/socket/user-events/chat.js
@@ -284,6 +284,19 @@ module.exports.handleAddNewGameChat = async (socket, passport, data, game, modUs
 	// Prevents spamming commands
 	user.lastMessage = { timestamp: Date.now() };
 
+	if (game.general.slowChatMode && !AEM) {
+		if (!user.gameLastMessages) user.gameLastMessages = {};
+		const lastGameMessageTime = user.gameLastMessages[game.general.uid];
+		if (lastGameMessageTime && Date.now() - lastGameMessageTime < game.general.slowChatMode * 1000) {
+			socket.emit(
+				'sendAlert',
+				`Slow chat mode is on - you can send a message again in ${((lastGameMessageTime + game.general.slowChatMode * 1000 - Date.now()) / 1000).toFixed(1)} seconds.`
+			);
+			return;
+		}
+		user.gameLastMessages[game.general.uid] = Date.now();
+	}
+
 	if (chat[0] === '/') return runCommand(socket, passport, user, game, chat, AEM || (isTourneyMod && game.general.unlistedGame), Boolean(player));
 
 	const pingMods = /^@(mod|moderator|editor|aem|mods) (.*)$/i.exec(chat);

--- a/routes/socket/user-events/chat.test.js
+++ b/routes/socket/user-events/chat.test.js
@@ -1,0 +1,117 @@
+const { handleAddNewGameChat } = require('./chat');
+
+jest.mock('../models', () => ({
+	userList: [],
+	newStaff: { modUserNames: [], editorUserNames: [] },
+	generalChats: { list: [], sticky: '' },
+	getLastGenchatModPingAsync: jest.fn(),
+	setLastGenchatModPingAsync: jest.fn(),
+	emoteList: {},
+	getPrivateChatTruncate: jest.fn()
+}));
+jest.mock('../report.js');
+jest.mock('../chatReplacements', () => ({ chatReplacements: [] }));
+jest.mock('../commands');
+jest.mock('../util.js', () => ({
+	sendInProgressGameUpdate: jest.fn(),
+	sendPlayerChatUpdate: jest.fn(),
+	sendCommandChatsUpdate: jest.fn()
+}));
+jest.mock('../util', () => ({
+	sendInProgressGameUpdate: jest.fn(),
+	sendPlayerChatUpdate: jest.fn(),
+	sendCommandChatsUpdate: jest.fn()
+}));
+
+describe('handleAddNewGameChat', () => {
+	const makeSocket = () => ({ emit: jest.fn() });
+	const makeGame = (slowChatMode = false) => ({
+		general: {
+			uid: 'test-123',
+			playerChats: 'enabled',
+			disableObserver: false,
+			disableObserverLobby: false,
+			chatReplTime: Array(1).fill(0),
+			slowChatMode
+		},
+		gameState: { isStarted: true, isCompleted: false, isTracksFlipped: true },
+		publicPlayersState: [{ userName: 'alice' }],
+		private: { seatedPlayers: [{ playersState: [{}] }] },
+		chats: []
+	});
+	const makeUser = (overrides = {}) => ({
+		userName: 'alice',
+		staffRole: '',
+		wins: 0,
+		losses: 0,
+		xpOverall: 0,
+		isRainbowOverall: false,
+		lastMessage: null,
+		gameLastMessages: {},
+		...overrides
+	});
+
+	beforeEach(() => {
+		require('../models').userList.length = 0;
+	});
+
+	it('should allow normal chat when slowChatMode is off', async () => {
+		const socket = makeSocket();
+		const game = makeGame(false);
+		const user = makeUser();
+		require('../models').userList.push(user);
+
+		await handleAddNewGameChat(
+			socket,
+			{ user: 'alice' },
+			{ chat: 'hello world', uid: 'test-123' },
+			game,
+			[], [], []
+		);
+
+		expect(socket.emit).not.toHaveBeenCalled();
+		expect(game.chats.length).toBeGreaterThan(0);
+	});
+
+	it('should allow first chat when slowChatMode is on', async () => {
+		const socket = makeSocket();
+		const game = makeGame(5);
+		const user = makeUser();
+		require('../models').userList.push(user);
+
+		await handleAddNewGameChat(
+			socket,
+			{ user: 'alice' },
+			{ chat: 'first', uid: 'test-123' },
+			game,
+			[], [], []
+		);
+
+		expect(socket.emit).not.toHaveBeenCalledWith('sendAlert', expect.stringContaining('Slow chat mode'));
+	});
+
+	it('should block rapid second chat when slowChatMode is on', async () => {
+		const socket = makeSocket();
+		const game = makeGame(5);
+		const now = Date.now();
+		const user = makeUser({
+			lastMessage: { timestamp: now - 5000 },
+			gameLastMessages: { 'test-123': now - 1000 }
+		});
+		require('../models').userList.push(user);
+
+		await handleAddNewGameChat(
+			socket,
+			{ user: 'alice' },
+			{ chat: 'second', uid: 'test-123' },
+			game,
+			[], [], []
+		);
+
+		expect(socket.emit).toHaveBeenCalledWith(
+			'sendAlert',
+			expect.stringContaining('Slow chat mode is on')
+		);
+		expect(game.chats.length).toBe(0);
+	});
+});

--- a/routes/socket/user-events/create-game.js
+++ b/routes/socket/user-events/create-game.js
@@ -221,6 +221,14 @@ module.exports.handleAddNewGame = async (socket, passport, data) => {
 		return;
 	}
 
+	if (typeof data.slowChatMode === 'object') {
+		return;
+	}
+
+	if (typeof data.slowChatMode === 'number' && (data.slowChatMode < 2 || data.slowChatMode > 15)) {
+		return;
+	}
+
 	const customGame = data.customGameSettings?.enabled; // ranked in order of precedent, higher up is the game mode if two are (somehow) selected
 	const casualGame =
 		(data.casualGame || (typeof data.timedMode === 'number' && data.timedMode < 30)
@@ -283,7 +291,8 @@ module.exports.handleAddNewGame = async (socket, passport, data) => {
 			xpMinimum: data.xpSliderValue,
 			avalonSH: data.avalonSH ? { withPercival: Boolean(data.withPercival) } : null,
 			monarchistSH: Boolean(data.monarchistSH),
-			noTopdecking: data.noTopdecking
+			noTopdecking: data.noTopdecking,
+			slowChatMode: typeof data.slowChatMode === 'number' && data.slowChatMode >= 2 && data.slowChatMode <= 15 ? data.slowChatMode : false
 		},
 		customGameSettings: data.customGameSettings,
 		publicPlayersState: [],

--- a/src/frontend-scripts/components/section-main/Creategame.jsx
+++ b/src/frontend-scripts/components/section-main/Creategame.jsx
@@ -52,6 +52,8 @@ export default class Creategame extends React.Component {
 			avalonSH: false,
 			withPercival: false,
 			monarchistSH: false,
+			slowChatMode: false,
+			slowChatSliderValue: [3],
 			customGameSettings: {
 				enabled: false,
 				// Valid powers: investigate, deckpeek, election, bullet; null for no power
@@ -602,20 +604,22 @@ export default class Creategame extends React.Component {
 					isEloLimited: false,
 					xpSliderValue: [0],
 					isXPLimited: false,
-					customGameSettings: {
-						enabled: false,
-						// Valid powers: investigate, deckpeek, election, bullet; null for no power
-						powers: [null, null, null, null, null], // last "power" is always a fas victory
-						hitlerZone: 3, // 1-5
-						vetoZone: 5, // 1-5, must be larger than fas track state
-						fascistCount: 1, // 1-3, does not include hit
-						hitKnowsFas: false,
-						fasCanShootHit: false,
-						deckState: { lib: 6, fas: 11 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
-						trackState: { lib: 0, fas: 0 }
-					}
-				});
-				break;
+						customGameSettings: {
+							enabled: false,
+							// Valid powers: investigate, deckpeek, election, bullet; null for no power
+							powers: [null, null, null, null, null], // last "power" is always a fas victory
+							hitlerZone: 3, // 1-5
+							vetoZone: 5, // 1-5, must be larger than fas track state
+							fascistCount: 1, // 1-3, does not include hit
+							hitKnowsFas: false,
+							fasCanShootHit: false,
+							deckState: { lib: 6, fas: 11 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
+							trackState: { lib: 0, fas: 0 }
+						},
+						slowChatMode: false,
+						slowChatSliderValue: [3]
+					});
+					break;
 			case 'High ELO':
 				this.setState({
 					gameName: 'High ELO',
@@ -643,20 +647,22 @@ export default class Creategame extends React.Component {
 					isEloLimited: true,
 					xpSliderValue: [0],
 					isXPLimited: false,
-					customGameSettings: {
-						enabled: false,
-						// Valid powers: investigate, deckpeek, election, bullet; null for no power
-						powers: [null, null, null, null, null], // last "power" is always a fas victory
-						hitlerZone: 3, // 1-5
-						vetoZone: 5, // 1-5, must be larger than fas track state
-						fascistCount: 1, // 1-3, does not include hit
-						hitKnowsFas: false,
-						fasCanShootHit: false,
-						deckState: { lib: 6, fas: 11 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
-						trackState: { lib: 0, fas: 0 }
-					}
-				});
-				break;
+						customGameSettings: {
+							enabled: false,
+							// Valid powers: investigate, deckpeek, election, bullet; null for no power
+							powers: [null, null, null, null, null], // last "power" is always a fas victory
+							hitlerZone: 3, // 1-5
+							vetoZone: 5, // 1-5, must be larger than fas track state
+							fascistCount: 1, // 1-3, does not include hit
+							hitKnowsFas: false,
+							fasCanShootHit: false,
+							deckState: { lib: 6, fas: 11 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
+							trackState: { lib: 0, fas: 0 }
+						},
+						slowChatMode: false,
+						slowChatSliderValue: [3]
+					});
+					break;
 			case 'Gun Game':
 				this.setState({
 					gameName: 'Gun Game',
@@ -684,20 +690,22 @@ export default class Creategame extends React.Component {
 					isEloLimited: false,
 					xpSliderValue: [0],
 					isXPLimited: false,
-					customGameSettings: {
-						enabled: true,
-						// Valid powers: investigate, deckpeek, election, bullet; null for no power
-						powers: ['bullet', 'bullet', 'bullet', 'bullet', 'bullet'], // last "power" is always a fas victory
-						hitlerZone: 4, // 1-5
-						vetoZone: 5, // 1-5, must be larger than fas track state
-						fascistCount: 1, // 1-3, does not include hit
-						hitKnowsFas: false,
-						fasCanShootHit: false,
-						deckState: { lib: 6, fas: 13 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
-						trackState: { lib: 0, fas: 0 }
-					}
-				});
-				break;
+						customGameSettings: {
+							enabled: true,
+							// Valid powers: investigate, deckpeek, election, bullet; null for no power
+							powers: ['bullet', 'bullet', 'bullet', 'bullet', 'bullet'], // last "power" is always a fas victory
+							hitlerZone: 4, // 1-5
+							vetoZone: 5, // 1-5, must be larger than fas track state
+							fascistCount: 1, // 1-3, does not include hit
+							hitKnowsFas: false,
+							fasCanShootHit: false,
+							deckState: { lib: 6, fas: 13 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
+							trackState: { lib: 0, fas: 0 }
+						},
+						slowChatMode: false,
+						slowChatSliderValue: [3]
+					});
+					break;
 			case '2R1H':
 				this.setState({
 					gameName: '2 Rooms 1 Hitler',
@@ -726,20 +734,22 @@ export default class Creategame extends React.Component {
 					isEloLimited: false,
 					xpSliderValue: [0],
 					isXPLimited: false,
-					customGameSettings: {
-						enabled: false,
-						// Valid powers: investigate, deckpeek, election, bullet; null for no power
-						powers: [null, null, null, null, null], // last "power" is always a fas victory
-						hitlerZone: 3, // 1-5
-						vetoZone: 5, // 1-5, must be larger than fas track state
-						fascistCount: 1, // 1-3, does not include hit
-						hitKnowsFas: false,
-						fasCanShootHit: false,
-						deckState: { lib: 6, fas: 11 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
-						trackState: { lib: 0, fas: 0 }
-					}
-				});
-				break;
+						customGameSettings: {
+							enabled: false,
+							// Valid powers: investigate, deckpeek, election, bullet; null for no power
+							powers: [null, null, null, null, null], // last "power" is always a fas victory
+							hitlerZone: 3, // 1-5
+							vetoZone: 5, // 1-5, must be larger than fas track state
+							fascistCount: 1, // 1-3, does not include hit
+							hitKnowsFas: false,
+							fasCanShootHit: false,
+							deckState: { lib: 6, fas: 11 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
+							trackState: { lib: 0, fas: 0 }
+						},
+						slowChatMode: false,
+						slowChatSliderValue: [3]
+					});
+					break;
 			case 'Silent Game':
 				this.setState({
 					gameName: 'Silent Game',
@@ -768,20 +778,22 @@ export default class Creategame extends React.Component {
 					isEloLimited: false,
 					xpSliderValue: [0],
 					isXPLimited: false,
-					customGameSettings: {
-						enabled: false,
-						// Valid powers: investigate, deckpeek, election, bullet; null for no power
-						powers: [null, null, null, null, null], // last "power" is always a fas victory
-						hitlerZone: 3, // 1-5
-						vetoZone: 5, // 1-5, must be larger than fas track state
-						fascistCount: 1, // 1-3, does not include hit
-						hitKnowsFas: false,
-						fasCanShootHit: false,
-						deckState: { lib: 6, fas: 11 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
-						trackState: { lib: 0, fas: 0 }
-					}
-				});
-				break;
+						customGameSettings: {
+							enabled: false,
+							// Valid powers: investigate, deckpeek, election, bullet; null for no power
+							powers: [null, null, null, null, null], // last "power" is always a fas victory
+							hitlerZone: 3, // 1-5
+							vetoZone: 5, // 1-5, must be larger than fas track state
+							fascistCount: 1, // 1-3, does not include hit
+							hitKnowsFas: false,
+							fasCanShootHit: false,
+							deckState: { lib: 6, fas: 11 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
+							trackState: { lib: 0, fas: 0 }
+						},
+						slowChatMode: false,
+						slowChatSliderValue: [3]
+					});
+					break;
 			case 'Tourney Game':
 				this.setState({
 					gameName: 'Tourney Game ',
@@ -852,20 +864,22 @@ export default class Creategame extends React.Component {
 					isEloLimited: false,
 					xpSliderValue: [0],
 					isXPLimited: false,
-					customGameSettings: {
-						enabled: true,
-						// Valid powers: investigate, deckpeek, election, bullet; null for no power
-						powers: ['investigate', 'reverseinv', 'investigate', 'reverseinv', 'investigate'], // last "power" is always a fas victory
-						hitlerZone: 3, // 1-5
-						vetoZone: 5, // 1-5, must be larger than fas track state
-						fascistCount: 2, // 1-3, does not include hit
-						hitKnowsFas: false,
-						fasCanShootHit: false,
-						deckState: { lib: 6, fas: 15 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
-						trackState: { lib: 0, fas: 0 }
-					}
-				});
-				break;
+						customGameSettings: {
+							enabled: true,
+							// Valid powers: investigate, deckpeek, election, bullet; null for no power
+							powers: ['investigate', 'reverseinv', 'investigate', 'reverseinv', 'investigate'], // last "power" is always a fas victory
+							hitlerZone: 3, // 1-5
+							vetoZone: 5, // 1-5, must be larger than fas track state
+							fascistCount: 2, // 1-3, does not include hit
+							hitKnowsFas: false,
+							fasCanShootHit: false,
+							deckState: { lib: 6, fas: 15 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
+							trackState: { lib: 0, fas: 0 }
+						},
+						slowChatMode: false,
+						slowChatSliderValue: [3]
+					});
+					break;
 			case 'Trivia Mode':
 				this.setState({
 					gameName: 'Trivia Mode',
@@ -894,20 +908,22 @@ export default class Creategame extends React.Component {
 					isEloLimited: false,
 					xpSliderValue: [0],
 					isXPLimited: false,
-					customGameSettings: {
-						enabled: true,
-						// Valid powers: investigate, deckpeek, election, bullet; null for no power
-						powers: ['bullet', 'bullet', 'bullet', 'bullet', 'bullet'], // last "power" is always a fas victory
-						hitlerZone: 4, // 1-5
-						vetoZone: 5, // 1-5, must be larger than fas track state
-						fascistCount: 2, // 1-3, does not include hit
-						hitKnowsFas: true,
-						fasCanShootHit: true,
-						deckState: { lib: 6, fas: 19 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
-						trackState: { lib: 0, fas: 0 }
-					}
-				});
-				break;
+						customGameSettings: {
+							enabled: true,
+							// Valid powers: investigate, deckpeek, election, bullet; null for no power
+							powers: ['bullet', 'bullet', 'bullet', 'bullet', 'bullet'], // last "power" is always a fas victory
+							hitlerZone: 4, // 1-5
+							vetoZone: 5, // 1-5, must be larger than fas track state
+							fascistCount: 2, // 1-3, does not include hit
+							hitKnowsFas: true,
+							fasCanShootHit: true,
+							deckState: { lib: 6, fas: 19 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
+							trackState: { lib: 0, fas: 0 }
+						},
+						slowChatMode: false,
+						slowChatSliderValue: [3]
+					});
+					break;
 			case 'Reset':
 				this.setState({
 					gameName: '',
@@ -936,19 +952,21 @@ export default class Creategame extends React.Component {
 					isEloLimited: false,
 					xpSliderValue: [0],
 					isXPLimited: false,
-					customGameSettings: {
-						enabled: false,
-						// Valid powers: investigate, deckpeek, election, bullet; null for no power
-						powers: [null, null, null, null, null], // last "power" is always a fas victory
-						hitlerZone: 3, // 1-5
-						vetoZone: 5, // 1-5, must be larger than fas track state
-						fascistCount: 1, // 1-3, does not include hit
-						hitKnowsFas: false,
-						fasCanShootHit: false,
-						deckState: { lib: 6, fas: 11 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
-						trackState: { lib: 0, fas: 0 }
-					}
-				});
+						customGameSettings: {
+							enabled: false,
+							// Valid powers: investigate, deckpeek, election, bullet; null for no power
+							powers: [null, null, null, null, null], // last "power" is always a fas victory
+							hitlerZone: 3, // 1-5
+							vetoZone: 5, // 1-5, must be larger than fas track state
+							fascistCount: 1, // 1-3, does not include hit
+							hitKnowsFas: false,
+							fasCanShootHit: false,
+							deckState: { lib: 6, fas: 11 }, // includes tracks cards; 6 deck + 1 track = 5 in deck
+							trackState: { lib: 0, fas: 0 }
+						},
+						slowChatMode: false,
+						slowChatSliderValue: [3]
+					});
 		}
 	}
 
@@ -1077,7 +1095,8 @@ export default class Creategame extends React.Component {
 				avalonSH: this.state.avalonSH,
 				withPercival: this.state.avalonSH && this.state.withPercival,
 				monarchistSH: this.state.monarchistSH,
-				noTopdecking: this.state.noTopdecking ? this.state.noTopdecking[0] : 0
+				noTopdecking: this.state.noTopdecking ? this.state.noTopdecking[0] : 0,
+				slowChatMode: this.state.slowChatMode ? this.state.slowChatSliderValue[0] : false
 			};
 
 			if (this.state.isTourny) {
@@ -1230,6 +1249,10 @@ export default class Creategame extends React.Component {
 
 	xpSliderChange = xpSliderValue => {
 		this.setState({ xpSliderValue });
+	};
+
+	slowChatSliderChange = slowChatSliderValue => {
+		this.setState({ slowChatSliderValue });
 	};
 
 	renderEloSlider() {
@@ -1981,6 +2004,21 @@ export default class Creategame extends React.Component {
 						</div>
 					)}
 
+					{this.state.slowChatMode && (
+						<div className="row slowchat-slider">
+							<div className="sixteen wide column">
+								<Range
+									onChange={this.slowChatSliderChange}
+									defaultValue={[3]}
+									value={this.state.slowChatSliderValue}
+									min={2}
+									max={15}
+									marks={{ 2: '2s', 3: '', 4: '', 5: '5s', 6: '', 7: '', 8: '', 9: '', 10: '10s', 11: '', 12: '', 13: '', 14: '', 15: '15s' }}
+								/>
+							</div>
+						</div>
+					)}
+
 					<div className="row timedmode-check"></div>
 					{this.props.userInfo.verified && !this.state.privateonlygame && (
 						<div className="row verified-row">
@@ -2054,6 +2092,27 @@ export default class Creategame extends React.Component {
 									this.setState({ timedMode: checked });
 								}}
 								checked={this.state.timedMode}
+								onColor="#627cc8"
+								offColor="#444444"
+								uncheckedIcon={false}
+								checkedIcon={false}
+								height={21}
+								width={48}
+								handleDiameter={21}
+							/>
+						</div>
+						<div className="four wide column">
+							{this.state.slowChatMode && (
+								<span className="timed-slider-value">{this.state.slowChatSliderValue[0]}s</span>
+							)}
+							<i className="big snail icon" />
+							<h4 className="ui header">Slow chat mode - limits how often players can send chat messages.</h4>
+							<Switch
+								className="create-game-switch"
+								onChange={checked => {
+									this.setState({ slowChatMode: checked });
+								}}
+								checked={this.state.slowChatMode}
 								onColor="#627cc8"
 								offColor="#444444"
 								uncheckedIcon={false}

--- a/src/frontend-scripts/components/section-main/DisplayLobbies.jsx
+++ b/src/frontend-scripts/components/section-main/DisplayLobbies.jsx
@@ -83,6 +83,8 @@ const DisplayLobbies = props => {
 		let monarchistSHTooltip;
 		let noTopdecking;
 		let noTopdeckingTooltip;
+		let slowChatMode;
+		let slowChatModeTooltip;
 		let timedMode;
 		let timedModeTooltip;
 		let isVerifiedOnly;
@@ -203,6 +205,16 @@ const DisplayLobbies = props => {
 			noTopdeckingTooltip = game.noTopdecking === 2 ? 'No Double Topdecking' : 'No Topdecking';
 		}
 
+		if (game.slowChatMode) {
+			slowChatMode = (
+				<span style={{ color: 'lightblue' }}>
+					<i className="comments outline icon" />
+					{game.slowChatMode}s
+				</span>
+			);
+			slowChatModeTooltip = `Slow Chat Mode - players can only send a message every ${game.slowChatMode} seconds`;
+		}
+
 		if (game.timedMode) {
 			timedMode = (
 				<span style={{ color: 'peru' }}>
@@ -308,6 +320,11 @@ const DisplayLobbies = props => {
 				{noTopdecking && (
 					<span data-tooltip={noTopdeckingTooltip} data-inverted="">
 						{noTopdecking}
+					</span>
+				)}
+				{slowChatMode && (
+					<span data-tooltip={slowChatModeTooltip} data-inverted="">
+						{slowChatMode}
 					</span>
 				)}
 				{rainbowgame && (

--- a/src/frontend-scripts/components/section-main/creategame.test.js
+++ b/src/frontend-scripts/components/section-main/creategame.test.js
@@ -8,4 +8,11 @@ describe('Creategame', () => {
 
 		expect(component).toHaveLength(1);
 	});
+
+	it('should default slowChatMode to false and slowChatSliderValue to [3]', () => {
+		const component = shallow(<Creategame userList={{ list: [] }} userInfo={{ gameSettings: {} }} />);
+
+		expect(component.state('slowChatMode')).toBe(false);
+		expect(component.state('slowChatSliderValue')).toEqual([3]);
+	});
 });


### PR DESCRIPTION
## Summary
Adds a new **Slow Chat Mode** setting when creating a game lobby. When enabled, players must wait a configurable number of seconds (2–15s) between messages. This applies uniformly to all non-staff players in the game.

## Motivation
Prevents players from gaining an advantage by spamming chat messages rapidly.

## Changes
- **Frontend (\`Creategame.jsx\`)**: New toggle + \`rc-slider\` for cooldown duration
- **Backend (\`create-game.js\`)**: Input validation and storage on \`game.general.slowChatMode\`
- **Schema (\`models/game.js\`)**: Added \`slowChatMode: Number\`
- **Lobby list (\`models.js\`, \`DisplayLobbies.jsx\`)**: Shows 🗨️ {N}s icon with tooltip
- **Chat (\`chat.js\`)**: Per-game cooldown enforcement using \`user.gameLastMessages[uid]\`
- **Remakes**: Setting carries over automatically via \`_.cloneDeep\`
- **Tests**: \`creategame.test.js\` + new \`chat.test.js\`

## Testing
- Existing test suite passes (43 suites, 161 tests)
- New tests cover default state and throttle logic