### PR TITLE
Add unanimous TD-out voting

### DIFF
--- a/__test__/backend/routes/socket/game-schemas.schema.test.js
+++ b/__test__/backend/routes/socket/game-schemas.schema.test.js
@@ -1,6 +1,6 @@
 import { assassinateSchema } from "../../../../routes/socket/game/assassination.schema";
 import { selectChancellorSchema } from "../../../../routes/socket/game/election-util.schema";
-import { voteSchema, policySelectionSchema } from "../../../../routes/socket/game/election.schema";
+import { voteSchema, policySelectionSchema, tdOutSchema } from "../../../../routes/socket/game/election.schema";
 import { playerIndexSchema, voteSchema as ppVoteSchema } from "../../../../routes/socket/game/policy-powers.schema";
 
 // Each game handler used to deref a wire field directly (seatedPlayers[data.playerIndex],
@@ -64,5 +64,19 @@ describe("policySelectionSchema (integer selection field)", () => {
     expect(policySelectionSchema.safeParse({ selection: {} }).success).toBe(false);
     expect(policySelectionSchema.safeParse({ selection: 1.5 }).success).toBe(false);
     expect(policySelectionSchema.safeParse({ uid: "g" }).success).toBe(false);
+  });
+});
+
+describe("tdOutSchema (boolean tdOutStatus field)", () => {
+  it("accepts boolean TD-out toggles from the client", () => {
+    expect(tdOutSchema.safeParse({ tdOutStatus: true, uid: "g" }).success).toBe(true);
+    expect(tdOutSchema.safeParse({ tdOutStatus: false, uid: "g" }).success).toBe(true);
+  });
+
+  it("rejects non-boolean / missing tdOutStatus and non-object data", () => {
+    expect(tdOutSchema.safeParse({ tdOutStatus: "yes" }).success).toBe(false);
+    expect(tdOutSchema.safeParse({ tdOutStatus: 1 }).success).toBe(false);
+    expect(tdOutSchema.safeParse({ uid: "g" }).success).toBe(false);
+    expect(tdOutSchema.safeParse(undefined).success).toBe(false);
   });
 });

--- a/__test__/backend/routes/socket/handlers-schema-wired.test.js
+++ b/__test__/backend/routes/socket/handlers-schema-wired.test.js
@@ -54,6 +54,7 @@ describe("every schema-guarded socket handler has its schema wired", () => {
   // game/ handlers
   it.each([
     ["selectVoting", () => election.selectVoting(P, game(), D, null, false)],
+    ["selectTdOut", () => election.selectTdOut(P, game(), D, null)],
     ["selectPresidentVoteOnVeto", () => election.selectPresidentVoteOnVeto(P, game(), D, null)],
     ["selectChancellorVoteOnVeto", () => election.selectChancellorVoteOnVeto(P, game(), D, null)],
     ["selectChancellorPolicy", () => election.selectChancellorPolicy(P, game(), D, false, null)],

--- a/__test__/backend/routes/socket/td-out-state.test.js
+++ b/__test__/backend/routes/socket/td-out-state.test.js
@@ -1,0 +1,85 @@
+const {
+  clearTdOutVotes,
+  getTdOutPublicState,
+  hasTdOutVote,
+  isTdOutAvailable,
+  pruneTdOutVotes,
+} = require("../../../../routes/socket/game/td-out-state");
+
+const makeGame = ({
+  playerCount = 6,
+  deadSeats = [],
+  electionTrackerCount = 2,
+  phase = "selectingChancellor",
+  status = phase === "voting" ? "Vote on election #3 now." : "Election #3: president to select chancellor.",
+  isTracksFlipped = true,
+  isCompleted = false,
+  isGameFrozen = false,
+  isRemade = false,
+} = {}) => ({
+  general: {
+    isRemade,
+    isTourny: false,
+    status,
+  },
+  gameState: {
+    phase,
+    isTracksFlipped,
+    isCompleted,
+    isGameFrozen,
+  },
+  trackState: {
+    electionTrackerCount,
+  },
+  private: {
+    seatedPlayers: Array.from({ length: playerCount }, (_value, index) => ({
+      userName: `p${index}`,
+      isDead: deadSeats.includes(index),
+    })),
+    tdOutVotes: {},
+  },
+});
+
+describe("td-out state", () => {
+  it("is available after two failed elections with an even number of living players", () => {
+    expect(isTdOutAvailable(makeGame())).toBe(true);
+    expect(isTdOutAvailable(makeGame({ phase: "voting" }))).toBe(true);
+  });
+
+  it("is not available for the wrong tracker count, odd living count, or inactive phase", () => {
+    expect(isTdOutAvailable(makeGame({ electionTrackerCount: 1 }))).toBe(false);
+    expect(isTdOutAvailable(makeGame({ deadSeats: [0] }))).toBe(false);
+    expect(isTdOutAvailable(makeGame({ phase: "presidentSelectingPolicy" }))).toBe(false);
+    expect(isTdOutAvailable(makeGame({ phase: "voting", status: "Tallying results of ballots.." }))).toBe(false);
+  });
+
+  it("prunes dead-player votes and reports the public vote count", () => {
+    const game = makeGame({ deadSeats: [1] });
+    game.private.tdOutVotes = {
+      p0: true,
+      p1: true,
+      p2: true,
+    };
+
+    pruneTdOutVotes(game);
+
+    expect(game.private.tdOutVotes).toEqual({
+      p0: true,
+      p2: true,
+    });
+    expect(getTdOutPublicState(game)).toEqual({
+      isAvailable: false,
+      voteCount: 2,
+      requiredVotes: 5,
+    });
+  });
+
+  it("tracks and clears an individual player's vote", () => {
+    const game = makeGame();
+    game.private.tdOutVotes.p0 = true;
+
+    expect(hasTdOutVote(game, "p0")).toBe(true);
+    clearTdOutVotes(game);
+    expect(hasTdOutVote(game, "p0")).toBe(false);
+  });
+});

--- a/routes/socket/game/election.js
+++ b/routes/socket/game/election.js
@@ -18,7 +18,13 @@ const _ = require("lodash");
 const { makeReport } = require("../report.js");
 const { assassinateMerlin } = require("./assassination");
 const { completeGame } = require("./end-game");
-const { voteSchema, policySelectionSchema } = require("./election.schema");
+const { voteSchema, policySelectionSchema, tdOutSchema } = require("./election.schema");
+const {
+  clearTdOutVotes,
+  getTdOutPublicState,
+  isTdOutAvailable,
+  pruneTdOutVotes,
+} = require("./td-out-state");
 
 const powerMapping = {
   investigate: [investigateLoyalty, "The president must investigate the party membership of another player."],
@@ -61,6 +67,8 @@ const presidentPowers = [
 const enactPolicy = (game, team, socket) => {
   const index = game.trackState.enactedPolicies.length;
   const { experiencedMode } = game.general;
+
+  clearTdOutVotes(game);
 
   if (game.private.lock.selectChancellor) {
     game.private.lock.selectChancellor = false;
@@ -234,7 +242,7 @@ const enactPolicy = (game, team, socket) => {
           },
           process.env.NODE_ENV === "development" ? 100 : 2000
         );
-      } else if (powerToEnact && game.trackState.electionTrackerCount <= 2) {
+      } else if (powerToEnact && game.gameState.phase !== "tdOut" && game.trackState.electionTrackerCount <= 2) {
         const chat = {
           timestamp: new Date(),
           gameChat: true,
@@ -359,6 +367,11 @@ const enactPolicy = (game, team, socket) => {
           )[Symbol.toPrimitive]();
           sendInProgressGameUpdate(game);
         }
+      } else if (game.gameState.phase === "tdOut") {
+        game.general.status = "TD out is continuing. The next top policy is being enacted.";
+        game.trackState.electionTrackerCount = 3;
+        sendInProgressGameUpdate(game);
+        enactTopdeckPolicy(game, socket, "TD out continues and the next top policy is enacted.");
       } else {
         sendInProgressGameUpdate(game);
         addPreviousGovernmentStatus();
@@ -368,6 +381,86 @@ const enactPolicy = (game, team, socket) => {
       game.trackState.electionTrackerCount = 0;
     },
     process.env.NODE_ENV === "development" ? 100 : experiencedMode ? 1000 : 4000
+  );
+};
+
+const enactTopdeckPolicy = (
+  game,
+  socket,
+  chatText = "The third consecutive election has failed and the top policy is enacted."
+) => {
+  const { experiencedMode } = game.general;
+  const isTdOutInProgress = game.gameState.phase === "tdOut";
+
+  clearTdOutVotes(game);
+
+  if (
+    !isTdOutInProgress &&
+    (game.general.noTopdecking === 1 ||
+      (game.general.noTopdecking === 2 && game.trackState.consecutiveTopdecks >= 1))
+  ) {
+    game.chats.push({
+      timestamp: new Date(),
+      gameChat: true,
+      chat: [
+        {
+          text: "The game was topdecked.",
+        },
+      ],
+    });
+    game.publicPlayersState.forEach((player, i) => {
+      player.cardStatus.cardFront = "secretrole";
+      player.cardStatus.cardBack = game.private.seatedPlayers[i].role;
+      player.cardStatus.cardDisplayed = true;
+      player.cardStatus.isFlipped = false;
+    });
+    game.gameState.audioCue = "fascistsWin";
+    sendInProgressGameUpdate(game, true);
+
+    setTimeout(() => {
+      game.publicPlayersState.forEach((player) => {
+        player.cardStatus.isFlipped = true;
+      });
+      game.gameState.audioCue = "";
+
+      completeGame(game, "fascist");
+    }, 2000);
+
+    return;
+  } else if (!isTdOutInProgress && game.general.noTopdecking === 2) {
+    game.trackState.consecutiveTopdecks++;
+  }
+
+  const chat = {
+    timestamp: new Date(),
+    gameChat: true,
+    chat: [
+      {
+        text: chatText,
+      },
+    ],
+  };
+
+  game.gameState.previousElectedGovernment = [];
+
+  if (!game.general.disableGamechat) {
+    game.private.seatedPlayers.forEach((player) => {
+      player.gameChats.push(chat);
+    });
+
+    game.private.unSeatedGameChats.push(chat);
+  }
+
+  if (!game.gameState.undrawnPolicyCount) {
+    shufflePolicies(game);
+  }
+
+  game.gameState.undrawnPolicyCount--;
+  setTimeout(
+    () => {
+      enactPolicy(game, game.private.policies.shift(), socket);
+    },
+    process.env.NODE_ENV === "development" ? 100 : experiencedMode ? 500 : 2000
   );
 };
 
@@ -1400,6 +1493,127 @@ const selectPresidentPolicy = (passport, game, data, wasTimer, socket) => {
 
 module.exports.selectPresidentPolicy = selectPresidentPolicy;
 
+const clearActiveElectionForTdOut = (game) => {
+  if (game.general.timedMode && game.private.timerId) {
+    clearTimeout(game.private.timerId);
+    game.private.timerId = null;
+  }
+
+  game.gameState.timedModeEnabled = false;
+  game.gameState.pendingChancellorIndex = null;
+
+  if (game.private.voteSpamData) {
+    game.private.voteSpamData.forEach((voteSpamData) => {
+      if (voteSpamData.unvoteTimer !== -1) {
+        clearInterval(voteSpamData.unvoteTimer);
+        voteSpamData.unvoteTimer = -1;
+      }
+    });
+  }
+
+  game.private.lock.selectChancellor = false;
+  game.private.lock.tdOut = true;
+
+  game.publicPlayersState.forEach((player) => {
+    player.isLoader = false;
+    player.governmentStatus = "";
+    player.cardStatus.cardDisplayed = false;
+    player.cardStatus.isFlipped = false;
+  });
+
+  game.private.seatedPlayers.forEach((player) => {
+    player.cardFlingerState = [];
+    player.voteStatus = {
+      hasVoted: false,
+    };
+  });
+};
+
+const selectTdOut = (passport, game, data, socket) => {
+  const parsed = tdOutSchema.safeParse(data);
+  if (!parsed.success) return;
+  data = parsed.data;
+
+  if (game.gameState.isGameFrozen) {
+    if (socket) {
+      socket.emit("sendAlert", "A staff member has prevented this game from proceeding. Please wait.");
+    }
+    return;
+  }
+
+  if (game.general.isRemade) {
+    if (socket) {
+      socket.emit("sendAlert", "This game has been remade and is now no longer playable.");
+    }
+    return;
+  }
+
+  if (!isTdOutAvailable(game)) {
+    return;
+  }
+
+  const playerIndex = game.private.seatedPlayers.findIndex((player) => player.userName === passport.user);
+  const player = game.private.seatedPlayers[playerIndex];
+
+  if (!player || player.isDead) {
+    return;
+  }
+
+  const votes = pruneTdOutVotes(game);
+  const hadTdOutVote = Boolean(votes[player.userName]);
+
+  if (hadTdOutVote === data.tdOutStatus) {
+    if (socket) {
+      socket.emit("updateTdOutVoting", hadTdOutVote);
+    }
+    return;
+  }
+
+  if (data.tdOutStatus) {
+    votes[player.userName] = true;
+  } else {
+    delete votes[player.userName];
+  }
+
+  const tdOutState = getTdOutPublicState(game);
+
+  if (socket) {
+    socket.emit("updateTdOutVoting", Boolean(votes[player.userName]));
+  }
+
+  game.chats.push({
+    timestamp: new Date(),
+    gameChat: true,
+    chat: [
+      {
+        text: game.general.blindMode ? "Seat " : "Player ",
+      },
+      {
+        text: game.general.blindMode ? `{${playerIndex + 1}}` : `${passport.user} {${playerIndex + 1}}`,
+        type: "player",
+      },
+      {
+        text: data.tdOutStatus
+          ? ` has voted to TD out this game. (${tdOutState.voteCount}/${tdOutState.requiredVotes})`
+          : ` has rescinded their vote to TD out this game. (${tdOutState.voteCount}/${tdOutState.requiredVotes})`,
+      },
+    ],
+  });
+
+  if (tdOutState.voteCount >= tdOutState.requiredVotes) {
+    clearActiveElectionForTdOut(game);
+    game.trackState.electionTrackerCount = 3;
+    game.gameState.phase = "tdOut";
+    game.general.status = "All living players voted to TD out. The top policy is being enacted.";
+    sendInProgressGameUpdate(game, true);
+    enactTopdeckPolicy(game, socket, "All living players voted to TD out the game and the top policy is enacted.");
+  } else {
+    sendInProgressGameUpdate(game);
+  }
+};
+
+module.exports.selectTdOut = selectTdOut;
+
 /**
  * @param {object} passport - socket authentication.
  * @param {object} game - target game.
@@ -1435,6 +1649,7 @@ module.exports.selectVoting = (passport, game, data, socket, force = false) => {
     const { gameState } = game;
     const { presidentIndex } = gameState;
     const chancellorIndex = game.publicPlayersState.findIndex((player) => player.governmentStatus === "isChancellor");
+    clearTdOutVotes(game);
     game.trackState.consecutiveTopdecks = 0;
 
     game.private._chancellorPlayerName = game.private.seatedPlayers[chancellorIndex].userName;
@@ -1644,75 +1859,10 @@ module.exports.selectVoting = (passport, game, data, socket, force = false) => {
   };
   const failedElection = () => {
     game.trackState.electionTrackerCount++;
+    clearTdOutVotes(game);
 
     if (game.trackState.electionTrackerCount >= 3) {
-      if (
-        game.general.noTopdecking === 1 ||
-        (game.general.noTopdecking === 2 && game.trackState.consecutiveTopdecks >= 1)
-      ) {
-        game.chats.push({
-          timestamp: new Date(),
-          gameChat: true,
-          chat: [
-            {
-              text: "The game was topdecked.",
-            },
-          ],
-        });
-        game.publicPlayersState.forEach((player, i) => {
-          player.cardStatus.cardFront = "secretrole";
-          player.cardStatus.cardBack = game.private.seatedPlayers[i].role;
-          player.cardStatus.cardDisplayed = true;
-          player.cardStatus.isFlipped = false;
-        });
-        game.gameState.audioCue = "fascistsWin";
-        sendInProgressGameUpdate(game, true);
-
-        setTimeout(() => {
-          game.publicPlayersState.forEach((player, i) => {
-            player.cardStatus.isFlipped = true;
-          });
-          game.gameState.audioCue = "";
-
-          completeGame(game, "fascist");
-        }, 2000);
-
-        return;
-      } else if (game.general.noTopdecking === 2) {
-        game.trackState.consecutiveTopdecks++;
-      }
-
-      const chat = {
-        timestamp: new Date(),
-        gameChat: true,
-        chat: [
-          {
-            text: "The third consecutive election has failed and the top policy is enacted.",
-          },
-        ],
-      };
-
-      game.gameState.previousElectedGovernment = [];
-
-      if (!game.general.disableGamechat) {
-        game.private.seatedPlayers.forEach((player) => {
-          player.gameChats.push(chat);
-        });
-
-        game.private.unSeatedGameChats.push(chat);
-      }
-
-      if (!game.gameState.undrawnPolicyCount) {
-        shufflePolicies(game);
-      }
-
-      game.gameState.undrawnPolicyCount--;
-      setTimeout(
-        () => {
-          enactPolicy(game, game.private.policies.shift(), socket);
-        },
-        process.env.NODE_ENV === "development" ? 100 : experiencedMode ? 500 : 2000
-      );
+      enactTopdeckPolicy(game, socket);
     } else {
       if (game.general.timedMode) {
         if (game.private.timerId) {

--- a/routes/socket/game/election.schema.js
+++ b/routes/socket/game/election.schema.js
@@ -6,5 +6,6 @@ const { voteSchema } = require("./wire-schemas");
 // depth boundary (3 is the highest valid value, the chancellor's enact); the per-context validity stays
 // in the handler, before the value indexes currentElectionPolicies / currentChancellorOptions.
 const policySelectionSchema = z.object({ selection: z.number().int().min(0).max(3) }).passthrough();
+const tdOutSchema = z.object({ tdOutStatus: z.boolean() }).passthrough();
 
-module.exports = { voteSchema, policySelectionSchema };
+module.exports = { voteSchema, policySelectionSchema, tdOutSchema };

--- a/routes/socket/game/start-game.js
+++ b/routes/socket/game/start-game.js
@@ -930,6 +930,7 @@ module.exports = (game) => {
   });
   game.gameState.audioCue = "";
   game.private.policies = [];
+  game.private.tdOutVotes = {};
   game.private.voteSpamData = game.private.seatedPlayers.map((player) => ({
     unvoteTimer: -1,
   }));

--- a/routes/socket/game/td-out-state.js
+++ b/routes/socket/game/td-out-state.js
@@ -1,0 +1,109 @@
+const TD_OUT_PHASES = new Set(["selectingChancellor", "voting"]);
+
+const getLivingPlayers = (game) => {
+  if (!game || !game.private || !Array.isArray(game.private.seatedPlayers)) {
+    return [];
+  }
+
+  return game.private.seatedPlayers.filter((player) => player && !player.isDead);
+};
+
+const getLivingPlayerNames = (game) => getLivingPlayers(game).map((player) => player.userName);
+
+const ensureTdOutVotes = (game) => {
+  if (!game || !game.private) {
+    return {};
+  }
+
+  if (!game.private.tdOutVotes || Array.isArray(game.private.tdOutVotes)) {
+    game.private.tdOutVotes = {};
+  }
+
+  return game.private.tdOutVotes;
+};
+
+const pruneTdOutVotes = (game) => {
+  const votes = ensureTdOutVotes(game);
+  const livingPlayerNames = new Set(getLivingPlayerNames(game));
+
+  Object.keys(votes).forEach((userName) => {
+    if (!livingPlayerNames.has(userName)) {
+      delete votes[userName];
+    }
+  });
+
+  return votes;
+};
+
+const isTdOutAvailable = (game) => {
+  const livingPlayerCount = getLivingPlayers(game).length;
+  const isActiveElection =
+    game &&
+    game.gameState &&
+    (game.gameState.phase === "selectingChancellor" ||
+      (game.gameState.phase === "voting" &&
+        game.general &&
+        typeof game.general.status === "string" &&
+        game.general.status.startsWith("Vote")));
+
+  return Boolean(
+    game &&
+      game.general &&
+      game.gameState &&
+      game.trackState &&
+      game.private &&
+      game.trackState.electionTrackerCount === 2 &&
+      livingPlayerCount > 0 &&
+      livingPlayerCount % 2 === 0 &&
+      TD_OUT_PHASES.has(game.gameState.phase) &&
+      isActiveElection &&
+      game.gameState.isTracksFlipped &&
+      !game.gameState.isCompleted &&
+      !game.gameState.isGameFrozen &&
+      !game.general.isRemade &&
+      !(game.general.isTourny && game.general.tournyInfo && game.general.tournyInfo.isCancelled)
+  );
+};
+
+const getTdOutVoteCount = (game) => {
+  const votes = pruneTdOutVotes(game);
+
+  return getLivingPlayerNames(game).filter((userName) => votes[userName]).length;
+};
+
+const getTdOutPublicState = (game) => {
+  const livingPlayers = getLivingPlayers(game);
+
+  return {
+    isAvailable: isTdOutAvailable(game),
+    voteCount: getTdOutVoteCount(game),
+    requiredVotes: livingPlayers.length,
+  };
+};
+
+const hasTdOutVote = (game, userName) => {
+  if (!userName) {
+    return false;
+  }
+
+  const votes = pruneTdOutVotes(game);
+
+  return Boolean(votes[userName]);
+};
+
+const clearTdOutVotes = (game) => {
+  if (game && game.private) {
+    game.private.tdOutVotes = {};
+  }
+};
+
+module.exports = {
+  clearTdOutVotes,
+  ensureTdOutVotes,
+  getLivingPlayerNames,
+  getTdOutPublicState,
+  getTdOutVoteCount,
+  hasTdOutVote,
+  isTdOutAvailable,
+  pruneTdOutVotes,
+};

--- a/routes/socket/routes.js
+++ b/routes/socket/routes.js
@@ -44,6 +44,7 @@ const {
 } = require("./user-requests");
 const {
   selectVoting,
+  selectTdOut,
   selectPresidentPolicy,
   selectChancellorPolicy,
   selectChancellorVoteOnVeto,
@@ -783,6 +784,13 @@ module.exports.socketRoutes = () => {
         const game = findGame(data);
         if (authenticated && ensureInGame(passport, game)) {
           selectVoting(passport, game, data, socket);
+        }
+      });
+      socket.on("updateTdOut", (data) => {
+        if (isRestricted) return;
+        const game = findGame(data);
+        if (authenticated && ensureInGame(passport, game)) {
+          selectTdOut(passport, game, data, socket);
         }
       });
       socket.on("selectedPresidentPolicy", (data) => {

--- a/routes/socket/user-events/create-game.js
+++ b/routes/socket/user-events/create-game.js
@@ -327,6 +327,7 @@ module.exports.handleAddNewGame = async (socket, passport, data) => {
       lock: {},
       votesPeeked: false,
       remakeVotesPeeked: false,
+      tdOutVotes: {},
       invIndex: -1,
       hiddenInfoChat: [],
       hiddenInfoSubscriptions: [],

--- a/routes/socket/user-events/remake-game.js
+++ b/routes/socket/user-events/remake-game.js
@@ -210,6 +210,7 @@ module.exports.handleUpdatedRemakeGame = (passport, game, data, socket) => {
       replayGameChats: [],
       lock: {},
       votesPeeked: false,
+      tdOutVotes: {},
       invIndex: -1,
       privatePassword: game.private.privatePassword,
       hiddenInfoChat: [],

--- a/routes/socket/util.js
+++ b/routes/socket/util.js
@@ -1,4 +1,5 @@
 const { newStaff } = require("./models");
+const { getTdOutPublicState, hasTdOutVote } = require("./game/td-out-state");
 const util = require("util");
 const { Webhook } = require("discord-webhook-node");
 const tempy = require("tempy");
@@ -56,6 +57,13 @@ const secureGame = (game) => {
   return _game;
 };
 
+const addTdOutState = (_game, game, userName) => {
+  _game.gameState = Object.assign({}, _game.gameState, {
+    tdOutVote: getTdOutPublicState(game),
+  });
+  _game.tdOutStatus = hasTdOutVote(game, userName);
+};
+
 const combineInProgressChats = (game, userName) =>
   userName && game.gameState.isTracksFlipped
     ? game.private.seatedPlayers.find((player) => player.userName === userName).gameChats.concat(game.chats)
@@ -99,6 +107,8 @@ module.exports.sendInProgressGameUpdate = (game, noChats = false) => {
     const _game = Object.assign({}, game);
     const { user } = sock.handshake.session.passport;
 
+    addTdOutState(_game, game, user);
+
     if (!game.gameState.isCompleted && game.gameState.isTracksFlipped) {
       const privatePlayer = _game.private.seatedPlayers.find((player) => user === player.userName);
 
@@ -129,6 +139,8 @@ module.exports.sendInProgressGameUpdate = (game, noChats = false) => {
     observerSockets.forEach((sock) => {
       const _game = Object.assign({}, game);
       const user = sock.handshake.session.passport ? sock.handshake.session.passport.user : null;
+
+      addTdOutState(_game, game, user);
 
       if (
         user &&

--- a/src/frontend-scripts/components/section-main/Tracks.jsx
+++ b/src/frontend-scripts/components/section-main/Tracks.jsx
@@ -12,6 +12,7 @@ class Tracks extends React.Component {
     super();
     this.state = {
       remakeStatus: false,
+      tdOutStatus: false,
       minutes: 0,
       seconds: 0,
       timedMode: false,
@@ -36,6 +37,11 @@ class Tracks extends React.Component {
           remakeStatus: status,
         });
       });
+      this.props.socket.on("updateTdOutVoting", (status) => {
+        this.setState({
+          tdOutStatus: status,
+        });
+      });
     }
   }
 
@@ -47,6 +53,10 @@ class Tracks extends React.Component {
 
     if (Notification && Notification.permission === "granted" && this.props.socket) {
       this.props.socket.off("pingPlayer");
+    }
+
+    if (this.props.socket) {
+      this.props.socket.off("updateTdOutVoting");
     }
   }
 
@@ -64,9 +74,20 @@ class Tracks extends React.Component {
       return;
     }
 
+    if (
+      nextProps.gameInfo &&
+      typeof nextProps.gameInfo.tdOutStatus === "boolean" &&
+      nextProps.gameInfo.tdOutStatus !== this.state.tdOutStatus
+    ) {
+      this.setState({
+        tdOutStatus: nextProps.gameInfo.tdOutStatus,
+      });
+    }
+
     if (!gameInfo.gameState.isStarted) {
       this.setState({
         remakeStatus: false,
+        tdOutStatus: false,
       });
     }
 
@@ -464,6 +485,15 @@ class Tracks extends React.Component {
         uid: gameInfo.general.uid,
       });
     };
+    const tdOutVote = gameInfo.gameState.tdOutVote || {};
+    const tdOutStatus =
+      typeof gameInfo.tdOutStatus === "boolean" ? gameInfo.tdOutStatus : this.state.tdOutStatus;
+    const updateTdOut = () => {
+      this.props.socket.emit("updateTdOut", {
+        tdOutStatus: !tdOutStatus,
+        uid: gameInfo.general.uid,
+      });
+    };
 
     const renderFasTrack = () => {
       if (gameInfo.customGameSettings && gameInfo.customGameSettings.enabled) {
@@ -755,6 +785,13 @@ class Tracks extends React.Component {
                 }
               />
             )}
+          {userInfo.userName && userInfo.isSeated && tdOutVote.isAvailable && (
+            <i
+              className={`icon check td-out ${tdOutStatus ? "enabled" : ""}`}
+              onClick={updateTdOut}
+              title={`Vote to TD out this game (${tdOutVote.voteCount || 0}/${tdOutVote.requiredVotes || 0})`}
+            />
+          )}
           {!showTimer && (minutes || seconds >= 15) && timedMode ? (
             <i title="Click to view Timer." className="hourglass half timer icon" onClick={this.toggleTimer}></i>
           ) : timedMode ? (

--- a/src/frontend-scripts/components/section-main/tracks.test.js
+++ b/src/frontend-scripts/components/section-main/tracks.test.js
@@ -6,6 +6,7 @@ describe("Tracks", () => {
   it("should initialize correctly", () => {
     const initialState = {
       remakeStatus: false,
+      tdOutStatus: false,
       minutes: 0,
       seconds: 0,
       timedMode: false,

--- a/src/scss/tracks.scss
+++ b/src/scss/tracks.scss
@@ -57,7 +57,8 @@
 		}
 	}
 	.icon.repeat,
-	.icon.remove {
+	.icon.remove,
+	.icon.check.td-out {
 		opacity: 1 !important;
 		position: absolute;
 		bottom: 5px;
@@ -75,6 +76,13 @@
 
 		&.enabled {
 			color: #db2828 !important;
+		}
+	}
+	.icon.check.td-out {
+		left: 34px;
+
+		&.enabled {
+			color: #21ba45 !important;
 		}
 	}
 	.player-count {


### PR DESCRIPTION
## Summary
- Add a unanimous TD-out checkmark for eligible even-player games after two failed governments.
- Let players rescind their TD-out vote until every living player agrees.
- Continue top-decking policies without elections or presidential powers until a team wins.

## Why
This shortens games that have reached an agreed-upon, repetitive top-deck finish while preserving a unanimous opt-in.

## Validation
- Targeted Jest suite: 50 tests passed.
- Biome and oxlint passed.
- Repository pre-commit lint passed.